### PR TITLE
add page on infrastructure best practices

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,9 +37,13 @@ navigation:
 - text: ATOs, the 18F way
   url: ato/
   internal: true
-- text: Amazon Web Services
-  url: aws/
+- text: Infrastructure
+  url: infrastructure/
   internal: true
+  children:
+  - text: Amazon Web Services
+    url: aws/
+    internal: true
 - text: Vulnerability scanning
   url: zap/
   internal: true

--- a/pages/aws.md
+++ b/pages/aws.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Web Services Standards
-permalink: /aws/
+permalink: /infrastructure/aws/
+parent: Infrastructure
 ---
 
 At 18F, we use [Amazon Web Services](http://aws.amazon.com/) (AWS) as our

--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -3,7 +3,7 @@ title: Infrastructure
 permalink: /infrastructure/
 ---
 
-Below is a list of "good" production ops practices, which product and tech leads should consider as part of their launch. We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.
+Below is a list of "good" production ops practices, which product and tech leads should consider early in their development and review as part of any major launch. Items in **bold** are considered must-haves. We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.
 
 ### Backups
 
@@ -42,14 +42,15 @@ Below is a list of "good" production ops practices, which product and tech leads
 - **User-representative tests (eg can access service, can perform a critical operation) running regularly**
 - Tests of sub-components also running regularly
 - Historical graph
-- Low latency
-- Track vs stated service-level targets
+- Tests are run frequently
+- Tests are reported with low-latency
+- Behavior vs stated service-level targets is tracked
 
 ### Alerting
 
 - **_Someone_ is alerted, somehow, if a monitor test is failing**
 - Flexible targets (for vacation, by component, etc), eg PagerDuty
-- "out of the norm" thresholds
+- Alerts triggered based on "out of the norm" thresholds
 - Flapping status does not result in excess/bouncing alerts
 
 ### Status communication
@@ -61,7 +62,7 @@ Below is a list of "good" production ops practices, which product and tech leads
 
 ### Security
 
-- **In-person discussion/audit around launch and disruptive changes**
+- **In-person discussion/audit around launch and major changes**
 - **Third-party services are approved to hold the data being sent to them**
 - Automated pen-testing in a staging environment as part of continuous deployment
 - Automated vuln-scanning in production environment that is fed with newly-discovered vulns

--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -1,0 +1,78 @@
+---
+title: Infrastructure
+permalink: /infrastructure/
+---
+
+Here's a list of "good" production ops practices, which product and tech leads should consider as part of their launch:
+
+- **Backups**
+    - **All volatile data storage is on redundant infrastructure**
+    - **Periodic snapshots of volatile data storage are happening**
+    - Ideally, point-in-time recovery is possible
+    - Recovery is documented in a testable procedure
+    - Tests of the recovery path are part of the continuous deployment pipeline
+- **Deployment**
+    - Can push a new version with a single command
+    - More than one person is able to do it
+    - Blue-green deployment
+    - Automated schema updates
+    - Snapshot/rollback of volatile data is incorporated in the process
+    - Deployment only includes production-necessary files
+    - Secrets are retrieved securely (eg via credential service rather than setting environment variables)
+    - Download, build, and configuration limited to staging, not runtime
+- **Support**
+    - Service-level targets are documented
+    - Clear entry point for complaints
+    - Clear escalation for handling infrastructure vs application vs api problems
+    - Support queue is public
+- **Logs**
+    - **Logs are captured to durable storage before rotation**
+    - **Logs with sensitive data are only available to appropriate people**
+    - Logs can be browsed/drilled with low-latency (eg grepping not necessary)
+- **Monitoring**
+    - **User-representative tests (eg can access service, can perform a critical operation) running regularly**
+    - Tests of sub-components also running regularly
+    - Historical graph
+    - Low latency
+    - Track vs stated service-level targets
+- **Alerting**
+    - **_Someone_ is alerted, somehow, if a monitor test is failing**
+    - Flexible targets (for vacation, by component, etc), eg PagerDuty
+    - "out of the norm" thresholds
+    - Flapping status does not result in excess/bouncing alerts
+- **Status communication**
+    - A status page is available to all users and downstream services
+    - The status page is hosted off-infrastructure
+    - The status page shows any planned and all previous outages
+    - Users can subscribe to notices
+- **Security**
+    - **In-person discussion/audit around launch and disruptive changes**
+    - **Third-party services are approved to hold the data being sent to them**
+    - Automated pen-testing in a staging environment as part of continuous deployment
+    - Automated vuln-scanning in production environment that is fed with newly-discovered vulns
+- ** Delegation of authority **
+    - **Authority to Operate (ATO) has been granted <<-- Gigantic**
+    - Certificates are specific to the domain
+    - Related DNS sub-domains are under the control of the hosting platform/staff
+- **Load-testing**
+    - Periodic tests of in-scope components in a staging environment as part of continuous deployment pipeline
+    - Upstream components are known to be load-tested up to max foreseeable pressure
+- **Capacity-planning**
+    - **Planning around launch, significant news, and seasonal deadlines**
+    - Analysis of similar service traffic in steady state
+    - Ideally app-relevant elastic response to scale up as needed and back down to control costs
+- **Scalability**
+    - **Each component has at least two instances at all times**
+    - Each component horizontally scalable with more instances
+    - Must-be-vertical components do not pressure their hosts in even elevated traffic condition
+    - Ideally must-be-vertical components do not share hosts
+- **Resilience**
+    - Instances are distributed across availability zones
+    - No in-app dependencies on the number/distribution of upstream instances
+    - Upstream is similarly resilient (multiple instances in multiple zones)
+- **Access Control**
+    - **Expected exposure for alpha/beta/blue-green environments is enforced**
+    - Exposure is controlled via configurable non-bespoke proxy (eg not the app)
+    - A/B cohorts/affinity supported
+
+We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.

--- a/pages/infrastructure.md
+++ b/pages/infrastructure.md
@@ -3,76 +3,101 @@ title: Infrastructure
 permalink: /infrastructure/
 ---
 
-Here's a list of "good" production ops practices, which product and tech leads should consider as part of their launch:
+Below is a list of "good" production ops practices, which product and tech leads should consider as part of their launch. We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.
 
-- **Backups**
-    - **All volatile data storage is on redundant infrastructure**
-    - **Periodic snapshots of volatile data storage are happening**
-    - Ideally, point-in-time recovery is possible
-    - Recovery is documented in a testable procedure
-    - Tests of the recovery path are part of the continuous deployment pipeline
-- **Deployment**
-    - Can push a new version with a single command
-    - More than one person is able to do it
-    - Blue-green deployment
-    - Automated schema updates
-    - Snapshot/rollback of volatile data is incorporated in the process
-    - Deployment only includes production-necessary files
-    - Secrets are retrieved securely (eg via credential service rather than setting environment variables)
-    - Download, build, and configuration limited to staging, not runtime
-- **Support**
-    - Service-level targets are documented
-    - Clear entry point for complaints
-    - Clear escalation for handling infrastructure vs application vs api problems
-    - Support queue is public
-- **Logs**
-    - **Logs are captured to durable storage before rotation**
-    - **Logs with sensitive data are only available to appropriate people**
-    - Logs can be browsed/drilled with low-latency (eg grepping not necessary)
-- **Monitoring**
-    - **User-representative tests (eg can access service, can perform a critical operation) running regularly**
-    - Tests of sub-components also running regularly
-    - Historical graph
-    - Low latency
-    - Track vs stated service-level targets
-- **Alerting**
-    - **_Someone_ is alerted, somehow, if a monitor test is failing**
-    - Flexible targets (for vacation, by component, etc), eg PagerDuty
-    - "out of the norm" thresholds
-    - Flapping status does not result in excess/bouncing alerts
-- **Status communication**
-    - A status page is available to all users and downstream services
-    - The status page is hosted off-infrastructure
-    - The status page shows any planned and all previous outages
-    - Users can subscribe to notices
-- **Security**
-    - **In-person discussion/audit around launch and disruptive changes**
-    - **Third-party services are approved to hold the data being sent to them**
-    - Automated pen-testing in a staging environment as part of continuous deployment
-    - Automated vuln-scanning in production environment that is fed with newly-discovered vulns
-- ** Delegation of authority **
-    - **Authority to Operate (ATO) has been granted <<-- Gigantic**
-    - Certificates are specific to the domain
-    - Related DNS sub-domains are under the control of the hosting platform/staff
-- **Load-testing**
-    - Periodic tests of in-scope components in a staging environment as part of continuous deployment pipeline
-    - Upstream components are known to be load-tested up to max foreseeable pressure
-- **Capacity-planning**
-    - **Planning around launch, significant news, and seasonal deadlines**
-    - Analysis of similar service traffic in steady state
-    - Ideally app-relevant elastic response to scale up as needed and back down to control costs
-- **Scalability**
-    - **Each component has at least two instances at all times**
-    - Each component horizontally scalable with more instances
-    - Must-be-vertical components do not pressure their hosts in even elevated traffic condition
-    - Ideally must-be-vertical components do not share hosts
-- **Resilience**
-    - Instances are distributed across availability zones
-    - No in-app dependencies on the number/distribution of upstream instances
-    - Upstream is similarly resilient (multiple instances in multiple zones)
-- **Access Control**
-    - **Expected exposure for alpha/beta/blue-green environments is enforced**
-    - Exposure is controlled via configurable non-bespoke proxy (eg not the app)
-    - A/B cohorts/affinity supported
+### Backups
 
-We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.
+- **All volatile data storage is on redundant infrastructure**
+- **Periodic snapshots of volatile data storage are happening**
+- Ideally, point-in-time recovery is possible
+- Recovery is documented in a testable procedure
+- Tests of the recovery path are part of the continuous deployment pipeline
+
+### Deployment
+
+- Can push a new version with a single command
+- More than one person is able to do it
+- Blue-green deployment
+- Automated schema updates
+- Snapshot/rollback of volatile data is incorporated in the process
+- Deployment only includes production-necessary files
+- Secrets are retrieved securely (eg via credential service rather than setting environment variables)
+- Download, build, and configuration limited to staging, not runtime
+
+### Support
+
+- Service-level targets are documented
+- Clear entry point for complaints
+- Clear escalation for handling infrastructure vs application vs api problems
+- Support queue is public
+
+### Logs
+
+- **Logs are captured to durable storage before rotation**
+- **Logs with sensitive data are only available to appropriate people**
+- Logs can be browsed/drilled with low-latency (eg grepping not necessary)
+
+### Monitoring
+
+- **User-representative tests (eg can access service, can perform a critical operation) running regularly**
+- Tests of sub-components also running regularly
+- Historical graph
+- Low latency
+- Track vs stated service-level targets
+
+### Alerting
+
+- **_Someone_ is alerted, somehow, if a monitor test is failing**
+- Flexible targets (for vacation, by component, etc), eg PagerDuty
+- "out of the norm" thresholds
+- Flapping status does not result in excess/bouncing alerts
+
+### Status communication
+
+- A status page is available to all users and downstream services
+- The status page is hosted off-infrastructure
+- The status page shows any planned and all previous outages
+- Users can subscribe to notices
+
+### Security
+
+- **In-person discussion/audit around launch and disruptive changes**
+- **Third-party services are approved to hold the data being sent to them**
+- Automated pen-testing in a staging environment as part of continuous deployment
+- Automated vuln-scanning in production environment that is fed with newly-discovered vulns
+
+###  Delegation of authority
+
+- **Authority to Operate (ATO) has been granted <<-- Gigantic**
+- Certificates are specific to the domain
+- Related DNS sub-domains are under the control of the hosting platform/staff
+
+### Load-testing
+
+- Periodic tests of in-scope components in a staging environment as part of continuous deployment pipeline
+- Upstream components are known to be load-tested up to max foreseeable pressure
+
+### Capacity-planning
+
+- **Planning around launch, significant news, and seasonal deadlines**
+- Analysis of similar service traffic in steady state
+- Ideally app-relevant elastic response to scale up as needed and back down to control costs
+
+### Scalability
+
+- **Each component has at least two instances at all times**
+- Each component horizontally scalable with more instances
+- Must-be-vertical components do not pressure their hosts in even elevated traffic condition
+- Ideally must-be-vertical components do not share hosts
+
+### Resilience
+
+- Instances are distributed across availability zones
+- No in-app dependencies on the number/distribution of upstream instances
+- Upstream is similarly resilient (multiple instances in multiple zones)
+
+### Access Control
+
+- **Expected exposure for alpha/beta/blue-green environments is enforced**
+- Exposure is controlled via configurable non-bespoke proxy (eg not the app)
+- A/B cohorts/affinity supported


### PR DESCRIPTION
Pulled directly from [the Trello card](https://trello.com/c/8o8LQrbI/273-checklist-of-prodops-best-practices-for-app-teams-with-cloud-gov-specifics), with a short intro and some formatting changes. We'll probably want to fill this out a bit (or at least link out to other places), but I think this is ok for now, just to start getting our guidelines in one place.

![screen shot 2015-12-17 at 6 23 59 pm](https://cloud.githubusercontent.com/assets/86842/11884994/96de29a8-a4eb-11e5-98a7-1268638542ad.png)

/cc @mogul @leahbannon 