### PR TITLE
Moved PII info from AWS page to its own page.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,10 @@ navigation:
 - text: Security
   url: security/
   internal: true
+  children:
+  - text: Personally Identifiable Information
+    url: pii/
+    internal: true
 - text: ATOs, the 18F way
   url: ato/
   internal: true

--- a/pages/ato-and-you.md
+++ b/pages/ato-and-you.md
@@ -7,7 +7,7 @@ An Authority to Operate (ATO) is a complicated security review process that is r
 
 First, make sure that your project is not more complicated than the typical Open Data ATO. The following are signs that your ATO process will be more complicated and you should consult Noah when you begin planning:
 
-* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../infrastructure/aws/))
+* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../security/pii/))
 * Any authentication?
 * Any authorization?
 * Is this the only place in the world you can do x? Is that x fundamental to what that agency does? (e.g. EPA tracking hazardous waste)

--- a/pages/ato.md
+++ b/pages/ato.md
@@ -52,5 +52,5 @@ One thing that will help the process is great documentation, which can mitigate 
 * 18F offers a 90 day authority to test security clearance process.
     * Estimated to take approximately 2 weeks to get materials together and information security team has a service level agreement of 2 weeks to approve a completed system security plan, do the testing, and give a 90 day authorization.
     * The 90 day ATO can be re-upped as long as the security boundary hasn’t changed; the automatic scans must not show any new vulnerabilities.
-* Sensitive PII is documented here; this process is not analogous to the PIA/SORN process and they must be handled separately
+* [Sensitive PII](../security/pii) is documented here; this process is not analogous to the PIA/SORN process and they must be handled separately
     * Broad safe harbor granted for when users may accidentally put their PII in; it must be actually requested.

--- a/pages/aws.md
+++ b/pages/aws.md
@@ -74,30 +74,7 @@ In order to make sure we are protecting the privacy and integrity of the public'
 
 Regardless of your own norms around privacy, always assume the owner of that data has the most conservative requirements unless they have taken express action, either through a communication or the system itself, telling you otherwise.
 
-We also take particular care in protecting sensitive personally identifiable information (PII). PII is any information that can be linked back to an individual. For example, this includes a person's full name, their home address, and their phone number.
-
-**Sensitive PII** is information which if lost, compromised, or disclosed without authorization, could result in substantial harm, embarrassment, inconvenience, or unfairness to an individual. While this is inherently a subjective definition, there are certain types of information we *always* treat as Sensitive PII:
-
-* Driver's license or state identification number
-* Social security number (SSN)
-* Financial account number(s)
-* Alien Registration Number
-* Passport number
-* Biometric identifiers
-
-Because we live in an increasingly connected world, sometimes sensitive PII can be created by pairing different types of PII. These types of PII become sensitive if paired:
-
-* Citizenship or immigration status
-* Ethnic or religious affiliation
-* Mother's maiden number
-* Last 4 digits of SSN
-* Medical information
-* Sexual orientation
-* Account passwords
-* Criminal history
-* Date of birth
-
-Sensitive PII **cannot be on a system unless it has received an Authority to Operate [xlink here].** If you are uncertain if the information you want to work with is Sensitive PII in your context, speak with 18F DevOps beforehand.
+We also take particular care in protecting [sensitive personally identifiable information (PII)](../../security/pii). PII is any information that can be linked back to an individual. For example, this includes a person's full name, their home address, and their phone number.
 
 ### Security
 

--- a/pages/pii.md
+++ b/pages/pii.md
@@ -1,0 +1,29 @@
+---
+title: Personally Identifiable Information 
+permalink: /security/pii/
+parent: Security
+---
+
+**Sensitive PII** is information which if lost, compromised, or disclosed without authorization, could result in substantial harm, embarrassment, inconvenience, or unfairness to an individual. While this is inherently a subjective definition, there are certain types of information we *always* treat as Sensitive PII:
+
+* Driver's license or state identification number
+* Social security number (SSN)
+* Financial account number(s)
+* Alien Registration Number
+* Passport number
+* Biometric identifiers
+
+Because we live in an increasingly connected world, sometimes sensitive PII can be created by pairing different types of PII. These types of PII become sensitive if paired:
+
+* Citizenship or immigration status
+* Ethnic or religious affiliation
+* Mother's maiden number
+* Last 4 digits of SSN
+* Medical information
+* Sexual orientation
+* Account passwords
+* Criminal history
+* Date of birth
+
+Sensitive PII **cannot be on a system unless it has received an [Authority to Operate](../../ato).** If you are uncertain if the information you want to work with is Sensitive PII in your context, speak with 18F DevOps beforehand.
+

--- a/pages/security.md
+++ b/pages/security.md
@@ -35,7 +35,7 @@ The system is _only_ available to:
 The system does _not_:
 
 * interact with or change the state of any production Federal information system, whether it is operated by 18F or our Federal partners.
-* collect or store any [sensitive PII](../aws/#other-people-39-s-information).
+* collect or store any [sensitive PII](../security/pii).
 
 
 ### 90 Day authorization


### PR DESCRIPTION
This PR makes the PII page a child of the `Security` page. All links are updated to refer to the new location.

Completes #45.