### PR TITLE
rearrange ATO pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,9 +42,22 @@ navigation:
   - text: Personally Identifiable Information
     url: pii/
     internal: true
-- text: ATOs, the 18F way
+- text: ATOs
   url: ato/
   internal: true
+  children:
+  - text: Background
+    url: background/
+    internal: true
+  - text: Levels
+    url: levels/
+    internal: true
+  - text: Checklist
+    url: checklist/
+    internal: true
+  - text: Authority to Test
+    url: authority-to-test/
+    internal: true
 - text: Infrastructure
   url: infrastructure/
   internal: true

--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,9 @@ navigation:
   - text: Checklist
     url: checklist/
     internal: true
+  - text: Tips
+    url: tips/
+    internal: true
   - text: Authority to Test
     url: authority-to-test/
     internal: true

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -2,7 +2,7 @@
 title: ATOs
 ---
 
-An Authority to Operate (ATO) is a complicated security review process that is required for deploying any web service on the public web.
+An Authority to Operate (ATO) is a complicated security review process that is required for deploying any web service on the public web. Before a system is made publicly accessible on the Internet, it must go through either the full ATO process or a 90-Day [Authority to Test](../authority-to-test/). If either are not yet complete, the system must have some level of authentication required for a user to enter.
 
 ### The ATO process
 

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -1,19 +1,8 @@
 ---
-title: ATOs, the 18F way
+title: ATOs
 ---
 
-## What is the Authority to Operate process
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/T1S52B1-NT4" frameborder="0" allowfullscreen></iframe>
-
-* Governed by the Federal Information Security Management Act of 2002, or FISMA
-    * FISMA does a few things. It puts the Chief Information Security Officer in charge of consulting the agency head with the process they should have for the security clearance process. FISMA also empowers the agency head with accepting all the risk posed by information systems.
-        * Good news is that agency head can delegate that authority at their choosing.
-    * This agency-specific process then binds agency heads with the process that they must then follow.
-        * In practice, what this means is setting up a series of controls for each new system that will be launched.
-* 18F simplifies this process by implementing the bulk of the controls at the infrastructure level to the AWS account. This is reflected in a baseline minimum controls we’ve created.
-    * Controls can range from human controls to business processes to mechanical ones.
-* Before a system is made publicly accessible on the Internet, it must go through either the full ATO process or a 90-Day Authority to Test. If either are not yet complete, the system must have some level of authentication required for a user to enter.
+An Authority to Operate (ATO) is a complicated security review process that is required for deploying any web service on the public web.
 
 ### The ATO process
 
@@ -38,18 +27,4 @@ While you’re in the ATO process, the following things will occur. These are la
     * A web framework having new backend administrative frameworks
     * The kinds of information you begin to store (e.g. personally identifiable information)
 
-## Tips
-
-One thing that will help the process is great documentation, which can mitigate some problems from occurring during the ATO process. Documentation, and specifically your README, should reflect a high level narrative of the architecture and data flows of the application. Questions to consider include:
-
-* What does it do?
-* How does it move information around?
-* What does it accomplish by doing it?
-
-## Optional - 90-day Authority to Test
-
-* 18F offers a 90 day authority to test security clearance process.
-    * Estimated to take approximately 2 weeks to get materials together and information security team has a service level agreement of 2 weeks to approve a completed system security plan, do the testing, and give a 90 day authorization.
-    * The 90 day ATO can be re-upped as long as the security boundary hasn’t changed; the automatic scans must not show any new vulnerabilities.
-* [Sensitive PII](../security/pii) is documented here; this process is not analogous to the PIA/SORN process and they must be handled separately
-    * Broad safe harbor granted for when users may accidentally put their PII in; it must be actually requested.
+See [the checklist](checklist/) to see these tasks broken down by who's responsible for each.

--- a/_pages/ato/authority-to-test.md
+++ b/_pages/ato/authority-to-test.md
@@ -1,0 +1,13 @@
+---
+title: Authority to Test
+---
+
+18F offers a 90-day Authority to Test security clearance process.
+
+* Estimated to take approximately 2 weeks to get materials together
+* Information security team has a service level agreement of 2 weeks to:
+    1. Approve a completed system security plan
+    1. Do the testing
+    1. Give a 90 day authorization
+* The 90 day ATO can be re-upped as long as the security boundary hasn’t changed.
+    * The automatic scans must not show any new vulnerabilities.

--- a/_pages/ato/background.md
+++ b/_pages/ato/background.md
@@ -1,0 +1,14 @@
+---
+title: Background on the ATO Process
+---
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/T1S52B1-NT4" frameborder="0" allowfullscreen></iframe>
+
+* Governed by the Federal Information Security Management Act of 2002, or FISMA
+    * FISMA does a few things. It puts the Chief Information Security Officer in charge of consulting the agency head with the process they should have for the security clearance process. FISMA also empowers the agency head with accepting all the risk posed by information systems.
+        * Good news is that agency head can delegate that authority at their choosing.
+    * This agency-specific process then binds agency heads with the process that they must then follow.
+        * In practice, what this means is setting up a series of controls for each new system that will be launched.
+* 18F simplifies this process by implementing the bulk of the controls at the infrastructure level to the AWS account. This is reflected in a baseline minimum controls we’ve created.
+    * Controls can range from human controls to business processes to mechanical ones.
+* Before a system is made publicly accessible on the Internet, it must go through either the full ATO process or a 90-Day Authority to Test. If either are not yet complete, the system must have some level of authentication required for a user to enter.

--- a/_pages/ato/background.md
+++ b/_pages/ato/background.md
@@ -9,6 +9,5 @@ title: Background on the ATO Process
         * Good news is that agency head can delegate that authority at their choosing.
     * This agency-specific process then binds agency heads with the process that they must then follow.
         * In practice, what this means is setting up a series of controls for each new system that will be launched.
-* 18F simplifies this process by implementing the bulk of the controls at the infrastructure level to the AWS account. This is reflected in a baseline minimum controls we’ve created.
+* 18F simplifies this process by implementing the bulk of the controls [at the infrastructure level](../../infrastructure/aws/) to the AWS account. This is reflected in a baseline minimum controls we’ve created.
     * Controls can range from human controls to business processes to mechanical ones.
-* Before a system is made publicly accessible on the Internet, it must go through either the full ATO process or a 90-Day Authority to Test. If either are not yet complete, the system must have some level of authentication required for a user to enter.

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -1,24 +1,6 @@
 ---
-title: Your ATO
+title: ATO Checklist
 ---
-
-An Authority to Operate (ATO) is a complicated security review process that is required for deploying any web service on the public web. [Learn more about ATOs](../ato/).
-
-First, make sure that your project is not more complicated than the typical Open Data ATO. The following are signs that your ATO process will be more complicated and you should consult Noah when you begin planning:
-
-* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../security/pii/))
-* Any authentication?
-* Any authorization?
-* Is this the only place in the world you can do x? Is that x fundamental to what that agency does? (e.g. EPA tracking hazardous waste)
-* Is the data not open?
-
-If you project is none of the above, you will likely be able to get an Open Data ATO, which is less complicated.
-
-Second, as soon as you have a stable server that isn’t changing its security boundary (talk to your devs about this, but it can be very early on), you should start this process. As long as there aren’t those significant changes, the tests will run periodically on any updates you make. At the very latest, start this process at least 2 months before launch. Do not commit to a launch date without coordinating with Noah Kunin on this first.
-
-Third, reach out to Noah to make sure he’s aware that you're about to start the application process (detailed below). You will know when you can set your launch date about six weeks later (likely sooner, but not reliably).
-
-## Steps to obtain an ATO
 
 To start the security clearance process, [create an issue in the DevOps repository](https://github.com/18F/DevOps/issues/new?title=ATO+for+%3Cproject%3E) using this template. Make sure to replace the placeholders at the top.
 
@@ -28,8 +10,8 @@ To start the security clearance process, [create an issue in the DevOps reposito
     * <url>
     * ...
 * **Site:** <url>
-* **Product manager:** @username
-* **Technical point of contact:** @username
+* **Product manager:** @<username>
+* **Technical point of contact:** @<username>
 * **Launch date/deadline:** <date>
 
 ## TODOs

--- a/_pages/ato/levels.md
+++ b/_pages/ato/levels.md
@@ -1,0 +1,22 @@
+---
+title: Levels of ATO
+---
+
+ATOs are broken down to the following levels:
+
+* Open Data
+* FISMA Low
+* FISMA Medium
+* FISMA High
+
+### Criteria for Open Data ATOs
+
+The following are signs that your ATO process cannot be categorized as Open Data, and thus will be more complicated:
+
+* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../security/pii/))
+* Any authentication?
+* Any authorization?
+* Is this the only place in the world you can do x? Is that x fundamental to what that agency does? (e.g. EPA tracking hazardous waste)
+* Is the data not open?
+
+If you will be using one of the FISMA levels, you should consult Noah when you begin planning.

--- a/_pages/ato/levels.md
+++ b/_pages/ato/levels.md
@@ -13,7 +13,7 @@ ATOs are broken down to the following levels:
 
 The following are signs that your ATO process cannot be categorized as Open Data, and thus will be more complicated:
 
-* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../security/pii/))
+* Are you dealing with Sensitive Personally Identifiable Information (PII)? ([see explanation](../../security/pii/))
 * Any authentication?
 * Any authorization?
 * Is this the only place in the world you can do x? Is that x fundamental to what that agency does? (e.g. EPA tracking hazardous waste)

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -3,7 +3,7 @@ title: Tips
 ---
 
 
-* Establish what [level](ato/levels/) your ATO will be.
+* Establish what [level](../levels/) your ATO will be.
 * As soon as you have a stable server that isn’t changing its security boundary (talk to your devs about this, but it can be very early on), you should start this process. As long as there aren’t those significant changes, the tests will run periodically on any updates you make. At the very latest, start this process at least 2 months before launch. Do not commit to a launch date without coordinating with Noah Kunin on this first.
 * Reach out to Noah to make sure he’s aware that you're about to start the application process (detailed below). You will know when you can set your launch date about six weeks later (likely sooner, but not reliably).
 * One thing that will help the process is great documentation, which can mitigate some problems from occurring during the ATO process. Documentation, and specifically your README, should reflect a high level narrative of the architecture and data flows of the application. Questions to consider include:

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -1,0 +1,12 @@
+---
+title: Tips
+---
+
+
+* Establish what [level](ato/levels/) your ATO will be.
+* As soon as you have a stable server that isn’t changing its security boundary (talk to your devs about this, but it can be very early on), you should start this process. As long as there aren’t those significant changes, the tests will run periodically on any updates you make. At the very latest, start this process at least 2 months before launch. Do not commit to a launch date without coordinating with Noah Kunin on this first.
+* Reach out to Noah to make sure he’s aware that you're about to start the application process (detailed below). You will know when you can set your launch date about six weeks later (likely sooner, but not reliably).
+* One thing that will help the process is great documentation, which can mitigate some problems from occurring during the ATO process. Documentation, and specifically your README, should reflect a high level narrative of the architecture and data flows of the application. Questions to consider include:
+    * What does it do?
+    * How does it move information around?
+    * What does it accomplish by doing it?

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -2,7 +2,6 @@
 title: Tips
 ---
 
-
 * Establish what [level](../levels/) your ATO will be.
 * As soon as you have a stable server that isn’t changing its security boundary (talk to your devs about this, but it can be very early on), you should start this process. As long as there aren’t those significant changes, the tests will run periodically on any updates you make. At the very latest, start this process at least 2 months before launch. Do not commit to a launch date without coordinating with Noah Kunin on this first.
 * Reach out to Noah to make sure he’s aware that you're about to start the application process (detailed below). You will know when you can set your launch date about six weeks later (likely sooner, but not reliably).

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -7,7 +7,7 @@ Despite the "Before You Ship" title, everything on this list should be considere
 
 ### Compliance
 
-* You need an Authority to Operate (ATO). At a very high level, it covers the security reviews and approvals **required** for public government websites. It is very important and can take months (albeit rarely). [Learn about requirements and timelines for getting your ATO here.](ato-and-you/)
+* You need an Authority to Operate (ATO). At a very high level, it covers the security reviews and approvals **required** for public government websites. It is very important and can take months (albeit rarely). [Learn about requirements and timelines for getting your ATO here.](ato/)
 
 ### Outreach
 

--- a/_pages/security/pii.md
+++ b/_pages/security/pii.md
@@ -3,7 +3,14 @@ title: Personally Identifiable Information
 parent: Security
 ---
 
-**Sensitive PII** is information which if lost, compromised, or disclosed without authorization, could result in substantial harm, embarrassment, inconvenience, or unfairness to an individual. While this is inherently a subjective definition, there are certain types of information we *always* treat as Sensitive PII:
+**Sensitive PII** is information which if lost, compromised, or disclosed without authorization, could result in substantial harm, embarrassment, inconvenience, or unfairness to an individual. Sensitive PII **cannot be on a system unless it has received an [Authority to Operate](../../ato).** If you are uncertain if the information you want to work with is Sensitive PII in your context, speak with 18F DevOps beforehand. Some notes:
+
+* This process is not analogous to the [PIA](http://www.gsa.gov/portal/content/102237)/[SORN](http://www.gsa.gov/portal/content/102236) process – those must be handled separately.
+* Broad safe harbor granted for when users may accidentally put their PII in; it must be actually requested.
+
+### Always
+
+While this is inherently a subjective definition, there are certain types of information we *always* treat as Sensitive PII:
 
 * Driver's license or state identification number
 * Social security number (SSN)
@@ -11,6 +18,8 @@ parent: Security
 * Alien Registration Number
 * Passport number
 * Biometric identifiers
+
+### Paired
 
 Because we live in an increasingly connected world, sometimes sensitive PII can be created by pairing different types of PII. These types of PII become sensitive if paired:
 
@@ -23,5 +32,3 @@ Because we live in an increasingly connected world, sometimes sensitive PII can 
 * Account passwords
 * Criminal history
 * Date of birth
-
-Sensitive PII **cannot be on a system unless it has received an [Authority to Operate](../../ato).** If you are uncertain if the information you want to work with is Sensitive PII in your context, speak with 18F DevOps beforehand.


### PR DESCRIPTION
This pull request splits up and rearranges the ATO-related pages.

![screen shot 2016-01-05 at 12 10 26 pm](https://cloud.githubusercontent.com/assets/86842/12121818/552d4fc0-b3a5-11e5-93c4-58203a96ae2d.png)

I only made very minor changes to the content itself, so I would review this pull request for the _organization_ of the content, rather than whether each page is "complete" or not.