### PR TITLE
Removing the Temporary Notes from the side nav.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,9 +99,6 @@ navigation:
 - text: Static Security Analysis
   url: static-security-analysis/
   internal: true
-- text: Temporary Notes
-  url: temporary-notes/
-  internal: true
 
 repos:
 - name: Guides Template


### PR DESCRIPTION
I broke the build by removing the temporary notes page without removing the entry from the nav. This removes it from the nav.