### PR TITLE
add a page on ATO delegation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,9 @@ navigation:
   - text: Controls
     url: controls/
     internal: true
+  - text: Delegation
+    url: delegation/
+    internal: true
 - text: Laws
   url: laws/
   internal: true

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -24,6 +24,7 @@ To start the security clearance process, [create an issue in the DevOps reposito
 
 ### Project team
 
+1. [ ] Initiate [ATO delegation](https://pages.18f.gov/before-you-ship/ato/delegation/)
 1. [ ] Add an [`about.yml`](https://github.com/18F/about_yml) for the main repository
 1. [ ] Run the [security scans](https://pages.18f.gov/before-you-ship/security/scanning/)
     * [ ] [Static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/)

--- a/_pages/ato/delegation.md
+++ b/_pages/ato/delegation.md
@@ -14,12 +14,14 @@ Note that a signed ATO delegation is critical and urgent; it clarifies and stipu
 
 To have ATO delegated to 18F, fill out the following template and send as a PDF to your partners' Authorizing Official. When signed, place it in [the `ATOs` folder](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) alongside your other ATO materials.
 
-> # Delegation of Authority to Operate
+> # Delegation of Authorization
 >
-> I, [NAME], the [AGENCY] Authorizing Official, hereby grant authority to 18F/GSA to accept the risk of operating information systems under the [PROJECT] name, which falls under Interagency Agreement [NUMBER]. This authority grants 18F/GSA the ability to select controls and test the system for to be granted an Authority to Operate. 18F/GSA will work independently to receive an Authority to Operate, and will bear responsibility of technical work associated with the process.
+> I, [NAME], the Authorizing Official for [DEPT/AGENCY DIVISION/TEAM], hereby accept 18F/GSA's authority to accept the risk of operating information systems for [PROGRAM OR LINE OF BUSINESS], which fall under Interagency Agreement [NUMBER]. This authority grants 18F/GSA the ability to determine risk, select controls, test the system, grant an authority to operate, and to ensure compliance with all relevant laws and regulations.
+>
+> 18F/GSA will work independently to receive an authority to operate and will bear responsibility of technical work associated with the process.
 >
 > \___________________
-> Signature
+> [NAME + TITLE]
 >
-> \_________
-> Date
+> \___________________
+> [DATE]

--- a/_pages/ato/delegation.md
+++ b/_pages/ato/delegation.md
@@ -1,0 +1,25 @@
+---
+title: ATO Delegation
+navtitle: Delegation
+parent: ATOs
+---
+
+Just as this risk acceptance authority can be delegated within an agency (as it is from the GSA Administrator to the Associate Administrator of OCSIT to 18F), it can be delegated across agencies. Since our ATO process is far more...efficient...than the process in other agencies, delegating the ATO to us means that applications can get launched quicker without as much time and effort required for compliance.
+
+ATOs are not a standardized concept across agencies, so each may have specific requirements for them. If an ATO is delegated to 18F, the partner agency is choosing to forego their own ATO requirements and allow 18F's Authorizing Official (Noah Kunin) to accept the risk on their behalf, using our ATO format. This is something that you should encourage your partners to accept.
+
+Note that a signed ATO delegation is critical and urgent; it clarifies and stipulates that the agency is not the system owner...18F/GSA is. Without it, there is a lack of clarity, potentially legal in nature, on who is the customer and who is the provider of this system.
+
+### Template
+
+To have ATO delegated to 18F, fill out the following template and send as a PDF to your partners' Authorizing Official. When signed, place it in [the `ATOs` folder](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) alongside your other ATO materials.
+
+> # Delegation of Authority to Operate
+>
+> I, [NAME], the [AGENCY] Authorizing Official, hereby grant authority to 18F/GSA to accept the risk of operating information systems under the [PROJECT] name, which falls under Interagency Agreement [NUMBER]. This authority grants 18F/GSA the ability to select controls and test the system for to be granted an Authority to Operate. 18F/GSA will work independently to receive an Authority to Operate, and will bear responsibility of technical work associated with the process.
+>
+> \___________________
+> Signature
+>
+> \_________
+> Date


### PR DESCRIPTION
Closes #65.

I saw the following from @NoahKunin in [Slack](https://18f.slack.com/archives/devops/p1452463552001746):

> Re ATO delegations, since I invented it, the memo says whatever I want it to say, and will accept, which is why I wrote the boilerplate

I looked around in Drive, and found the included template in a couple of PDFs. Added some introductory language that should be checked for correctness.

/cc @wslack 