### PR TITLE
Additional clarity around PR flow, copyright, and comms.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,29 @@
 
 We're so glad you're thinking about contributing to an 18F open source project! If you're unsure or afraid of anything, just ask or submit the issue or pull request anyways. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contribution, and don't want a wall of rules to get in the way of that.
 
-Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the 18F Open Source Policy GitHub repository at https://github.com/18f/open-source-policy, or just shoot us an email/official government letterhead note to [18f@gsa.gov](mailto:18f@gsa.gov).
+Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the 18F Open Source Policy GitHub repository at https://github.com/18f/open-source-policy, or just shoot us an note to [18f@gsa.gov](mailto:18f@gsa.gov).
 
 ## Guidelines
 
-For each task or informational page, there should clear indication of:
+For each task to complete "before you ship", there should be a clear indication of:
 
 * The "what" and the "when" (and maybe the "who")
 * The "how", either included in the site or with a link elsewhere
 * External links for:
     * The "why" (when available)
-    * The regulation text itself (where applicable)
+    * The legal or regulation text itself (where applicable)
     * Additional information
 * Whether it's a hard requirement or a guideline/recommendation/best practice
-* Where the item came from (government-wide, GSA, the 18F Infrastructure team, etc.)
+* Where the item came from (law, regulation, OMB Memo, GSA, the 18F Infrastructure team, etc.)
 * Where to get help, e.g.
     * A Slack channel
     * An email list
     * Where to file a GitHub issue
     * A specific person (if necessary)
+
+## Pull requests
+
+Please submit all pull requests to the `18f-internal` branch first. The repository's maintainers will take it from there, and accept, modify, or reject the request. Maintainers will also move the change to `18f-pages`, the production branch.
 
 ## Public domain
 
@@ -28,9 +32,9 @@ This project is in the public domain within the United States, and
 copyright and related rights in the work worldwide are waived through
 the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 
-All contributions to this project will be released under the CC0
-dedication. By submitting a pull request, you are agreeing to comply
-with this waiver of copyright interest.
+All contributions to this project are submitted under the CC0
+dedication. By submitting a commit, issue, or pull request, you are agreeing to comply
+with this waiver of copyright.
 
 ## Usage
 

--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -40,6 +40,15 @@ More info:
 * [Rails Security Guide](http://guides.rubyonrails.org/security.html)
 * [OWASP Rails Cheatsheet](https://www.owasp.org/index.php/Ruby_on_Rails_Cheatsheet)
 
+### Sinatra/Padrino
+
+* Set up [static security analysis](../static-analysis/#other-ruby-frameworks). We are currently seeking recommendations for this configuration.
+* Ensure that [rack-protection](https://github.com/sinatra/rack-protection) and/or [SecureHeaders](https://github.com/twitter/secureheaders) is enabled and configured.
+
+More info:
+
+* [Rails Security Guide](http://guides.rubyonrails.org/security.html) is not directly related, but contains pertinent information and descriptions of common vulnerabilities.
+
 ---
 
-Are we missing guidelines for the framework you're using? [Open an issue!](https://github.com/18F/before-you-ship/issues/new)
+Are we missing guidelines for the framework you're using, or think our guidelines could be improved? [Open an issue!](https://github.com/18F/before-you-ship/issues/new)

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -72,15 +72,7 @@ If you saved the config file elsewhere, you can also run:
 
 ##### Other Ruby Frameworks
 
-[Dawnscanner](https://github.com/thesp0nge/dawnscanner) is a scanner that supports Ruby on Rails, Sinatra, and Padrino. It makes an excellent second-line scanner for Rails applications, and a primary scanner for Sinatra & Padrino.
-
-To install:
-
-    $ gem install dawnscanner
-
-To scan from your project directory and get output in the console:
-
-    $ dawn -K .
+We do not have a recommended scanner for non-Rails frameworks. If there is a service or tool that works well, please [tell us about it](https://github.com/18F/before-you-ship/issues/new).
 
 #### Python
 


### PR DESCRIPTION
We don't need to call out "official govt letterhead" notes. Who/What/Where/Why for purely informational pages seems like overload and out of scope. 

New section on the desired flow between branches.

Minor technical updates to copyright section, to make it clear that the copyright providence of the repo is CC0 now, not some later date or version.