### PR TITLE
Removed DawnScanner from the tools list and added Sinatra framework advice

### DIFF
--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -40,6 +40,15 @@ More info:
 * [Rails Security Guide](http://guides.rubyonrails.org/security.html)
 * [OWASP Rails Cheatsheet](https://www.owasp.org/index.php/Ruby_on_Rails_Cheatsheet)
 
+### Sinatra/Padrino
+
+* Set up [static security analysis](../static-analysis/#other-ruby-frameworks). We are currently seeking recommendations for this configuration.
+* Ensure that [rack-protection](https://github.com/sinatra/rack-protection) and/or [SecureHeaders](https://github.com/twitter/secureheaders) is enabled and configured.
+
+More info:
+
+* [Rails Security Guide](http://guides.rubyonrails.org/security.html) is not directly related, but contains pertinent information and descriptions of common vulnerabilities.
+
 ---
 
-Are we missing guidelines for the framework you're using? [Open an issue!](https://github.com/18F/before-you-ship/issues/new)
+Are we missing guidelines for the framework you're using, or think our guidelines could be improved? [Open an issue!](https://github.com/18F/before-you-ship/issues/new)

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -72,15 +72,7 @@ If you saved the config file elsewhere, you can also run:
 
 ##### Other Ruby Frameworks
 
-[Dawnscanner](https://github.com/thesp0nge/dawnscanner) is a scanner that supports Ruby on Rails, Sinatra, and Padrino. It makes an excellent second-line scanner for Rails applications, and a primary scanner for Sinatra & Padrino.
-
-To install:
-
-    $ gem install dawnscanner
-
-To scan from your project directory and get output in the console:
-
-    $ dawn -K .
+We do not have a recommended scanner for non-Rails frameworks. If there is a service or tool that works well, please [tell us about it](https://github.com/18F/before-you-ship/issues/new).
 
 #### Python
 


### PR DESCRIPTION
DawnScanner currently is mostly for dependencies & Rails. We shouldn't recommend it for non-Rails apps. Adding a bit of info to the frameworks page regarding best practices for Sinatra & Padrino.