### PR TITLE
Some copyedits to make ATO-related pages easier to read

### DIFF
--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -10,15 +10,14 @@ While the ATO is the final compliance step that's required before launching an a
 
 ### Starting the ATO process
 
-1. Read through the [walkthrough](walkthrough/).
-1. Follow instructions on [the checklist](checklist/) page to kick off and set up a tracking mechanism for your ATO.
+To start the ATO process, follow the [walkthrough](walkthrough/).
 
 ### Re-authorization
 
-If the system substantively changes, then a new ATO will be warranted. Examples for triggers for a new ATO include changes to:
+If a system substantively changes, it'll need a new ATO. Examples for triggers for a new ATO include changes to:
 
 * Encryption methodologies
 * Administrative functionality within the application
 * The kinds of information you store (e.g. [personally identifiable information](../security/pii/))
 
-The 18F Infrastructure team will make this determination – please [open a new issue](https://github.com/18F/DevOps/issues/new?title=ATO+re-authorization+for+%3Cproject%3E?) if you think you have made a change that may warrant a new ATO.
+The 18F Infrastructure team will make this determination – please [open a new issue](https://github.com/18F/Infrastructure/issues/new?title=ATO+re-authorization+for+%3Cproject%3E?) if you think you have made a change that may require a new ATO.

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -34,7 +34,7 @@ You are welcome to ask any questions as comments in the issue or #infrastructure
 1. [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#downtime)
     * [ ] [Error alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors)
-1. [ ] Add an [`about.yml`](https://github.com/18F/about_yml) for the main repository
+1. [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository
 1. [ ] [Security scans](https://pages.18f.gov/before-you-ship/security/scanning/)
     * [ ] Set up [static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/) service
         * [ ] Add service badges to the README

--- a/_pages/ato/levels.md
+++ b/_pages/ato/levels.md
@@ -3,13 +3,13 @@ title: Levels of ATO
 navtitle: Levels
 ---
 
-In the [ATO Categorization](../categorize/) step, you picked an impact level (`low`, `medium`, `high`) for each of three metrics (`confidentiality`, `integrity`, and `availability`). The combination of these levels across the three metrics then correspond to an overall level:
+In the [ATO Categorization](../categorize/) step, you picked an impact level (`low`, `moderate`, `high`) for each of three metrics (`confidentiality`, `integrity`, and `availability`). The combination of these levels across the three metrics then correspond to an overall level:
 
 Overall level | Confidentiality | Integrity | Availability
 --- | --- | --- | ---
 **[Open Data](#open-data-atos)** | none | low | low
 **FISMA Low** | low | low | low
-**FISMA Medium** | medium | medium | medium
+**FISMA Moderate** | moderate | moderate | moderate
 **FISMA High** | high | high | high
 
 For more information, see [NIST 800-18](http://csrc.nist.gov/publications/nistpubs/800-18-Rev1/sp800-18-Rev1-final.pdf):

--- a/_pages/ato/walkthrough.md
+++ b/_pages/ato/walkthrough.md
@@ -4,25 +4,23 @@ navtitle: Walkthrough
 parent: ATOs
 ---
 
-### Step 0 - Consult 18F Infrastructure
+### Step 0 — Consult 18F Infrastructure
 
-As soon as you begin developing an [alpha](https://18f.gsa.gov/dashboard/stages/#alpha) (post [Intake](https://pages.18f.gov/intake/), [Agreement Financing](https://pages.18f.gov/intake/funding-and-iaa/), and [Discovery](https://18f.gsa.gov/dashboard/stages/#discovery)), [create your ATO checklist](../checklist/) to kick off the process. You can ask questions in that thread to understand the specific considerations for your system.
+As soon as you begin developing an [alpha](https://18f.gsa.gov/dashboard/stages/#alpha) (post [Intake](https://pages.18f.gov/intake/), [Agreement Financing](https://pages.18f.gov/intake/funding-and-iaa/), and [Discovery](https://18f.gsa.gov/dashboard/stages/#discovery)), [create your ATO checklist](../checklist/) to begin the ATO process and set up a tracking mechanism for your ATO. You can ask questions in your checklist thread to understand the specific considerations for your system.
 
-### Step 1 - Categorize
+### Step 1 — Categorize
 
-See the [ATO Categorization](../categorize/) page.
+Categorize your system's impact levels using the [ATO Categorization](../categorize/) guide.
 
-### Step 2 - Select controls
+### Step 2 — Select controls
 
-See the [Levels](../levels/) page to determine your system's baseline.
+Determine your system's overall level using the [Levels](../levels/) guide. This is your system's baseline.
 
-**"Controls" are the individual security requirements** laid out by the National Institute of Standards and Technology (NIST) – you can see a list of them on the [Controls](../controls/) page. [NIST 800-53 Table D-2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf#page=109) shows how each control maps to the overall baseline.
+Your system's baseline will determine the "controls" you need to implement. **"Controls" are individual security requirements** laid out by the National Institute of Standards and Technology (NIST) — for a list of them, see the [Controls](../controls/) page. [NIST 800-53 Table D-2](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf#page=109) shows how each control maps to a baseline.
 
-If your system does not fall into one of the buckets above (for example, you have a `low | moderate | moderate` system), you must create a new baseline. You will do this by making a new "certification schema" in [Compliance Masonry](https://github.com/opencontrol/compliance-masonry). It is possible to downgrade the level for any particular control, as long as it doesn't affect any other controls with a higher level (e.g. account management can be `low` if it doesn't allow you to edit confidential data). Note that there aren't that many specifics around what each level means for each control.
+If your system's impact levels don't match one of the "overall levels" listed  at [Levels](../levels/) (for example, you have a `low | moderate | moderate` system), you need to create a new baseline by making a new "certification schema" in [Compliance Masonry](https://github.com/opencontrol/compliance-masonry). Do this early on in your project. It's possible to downgrade the level for any particular control, as long as it doesn't affect any other controls with a higher level (e.g. account management can be `low` if it doesn't allow you to edit confidential data). Note that there aren't that many specifics around what each level means for each control.
 
-Do this early on in your project.
-
-### Step 3 - Implement the controls
+### Step 3 — Implement the controls
 
 This step is essentially "state how your system meets each of the regulations". Using established web frameworks (Rails, Django, etc.) and hosting in cloud.gov/AWS take care of a lot of the lower-level controls and security best practices for you, so you only need to be concerned with your application's custom code/configuration. This custom code/configuration is known as the "attack surface". For background:
 
@@ -35,23 +33,23 @@ The Compliance Masonry YAML file uses structured data to state how each control 
 
 * Not relevant to the system
 * Relevant to the system, and is one of the following:
-    * taken care of by (in Masonry, inherited from) one of:
-        * the platform (cloud.gov)
-        * the framework
-        * the authorization layer
-        * etc.
-    * implemented by you
-    * not yet taken care of
+    * Taken care of by (in Masonry, inherited from) one of:
+        * The platform (cloud.gov)
+        * The framework
+        * The authorization layer
+        * Etc.
+    * Implemented by you
+    * Not yet taken care of
 
 An "inherited" control would be something like FedRAMP requiring that fire extinguishers be present near the servers, which is something that AWS needs to worry about for _their_ compliance, and we don't need to re-explain when launching an application hosted there. Your Masonry file essentially contains the "overrides".
 
 The controls that are _not_ inherited from an underlying system must be listed in your Masonry file with a short explanation ("narrative"), and "implemented" before the system can receive an ATO. "Implementation" in the compliance sense is the same as in the code sense: ensure that the system meets that requirement, based on current industry best practices.
 
-### Step 4 - Assess the controls
+### Step 4 — Assess the controls
 
 In other words, "verify that your system is secure". To do so, run the [security scans](../../security/scanning/).
 
-### Step 5 - Authorize the system
+### Step 5 — Authorize the system
 
 The full list of data and functions in and of the system (in government parlance "mission based information types" and "delivery mechanisms") must be itemized in structured data. While the data types are obviously arbitrary and custom to each system we produce, the government has a formalized data set of mission functions that should be mapped to the system via NIST 800-60. For a Rails app, for example, this can simply be a link to the `db/schema.rb` file on GitHub.
 
@@ -63,7 +61,7 @@ You should send materials to the Authorizing Official (AO) as soon as the securi
 
 Once all of the materials are prepared and the system is considered "ready" by the Authorizing Official, they will sign the ATO.
 
-### Step 6 - Continuously monitor the controls
+### Step 6 — Continuously monitor the controls
 
 There are several ways to ensure that your system remains compliant:
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -15,7 +15,7 @@ Like with most things in 18F, this guide is a user-contributed work in progress.
 
 ### Compliance
 
-You need an Authority to Operate (ATO). Essentially, ATOs cover the important security reviews and approvals **required** for public government websites. They can take months (albeit rarely). You should review this [overview of ATOs](ato/) and these [tips](ato/tips/) to start planning.
+You need an Authority to Operate (ATO). Essentially, ATOs cover the important security reviews and approvals **required** for public government websites. They can take months (albeit rarely). You should review this [overview of ATOs](ato/) to start planning.
 
 ### Outreach
 

--- a/_pages/infrastructure/aws.md
+++ b/_pages/infrastructure/aws.md
@@ -43,7 +43,7 @@ There are a few special notes on using any IaaS in the Federal context.
 
 ### Other people's money
 
-The Federal Government cannot pay one penny more than it is authorized to spend. There is no retroactive justification for spends. When Government exceeds these limits, a report report and explanation is required to the GSA Administrator, General Counsel, and Congress. So tracking costs is a *big deal*.
+The Federal Government cannot pay one penny more than it is authorized to spend. There is no retroactive justification for spends. When Government exceeds these limits, a report and explanation is required to the GSA Administrator, General Counsel, and Congress. So tracking costs is a *big deal*.
 
 Every inter-agency agreement (IAA) at 18F needs to have a line item on a total value to spend on infrastructure, including Amazon Web Services (AWS). Unless it is part of a negotiation with 18F Infrastructure, we *do not* pay for non-production hosting costs. All costs must go back to the Federal partner or another funding source. There is no actual concept of _non-billable_ - there are only costs that are directly or indirectly billable. If we don't bill a funding source, it means that 18F's rates must go up that next fiscal year in order indirectly recoup costs.
 
@@ -57,7 +57,7 @@ The most important resources to tag are [EC2 instances](https://docs.aws.amazon.
 
 #### Format for the `client` tag
 
-18F Infrastructure maintains a [list of canonical unique identifiers](https://docs.google.com/spreadsheets/d/1hjCYIskgD_x_MI1ehXoiz2Qvsyxj1yK3fxabkezMPiE/edit#gid=0) (MB numbers) to use for all the `client` tags of a project. If you see your project missing, please contact the Director of Delivery Architecture in Slack.
+18F Infrastructure maintains a [list of canonical unique identifiers](https://docs.google.com/spreadsheets/d/1hjCYIskgD_x_MI1ehXoiz2Qvsyxj1yK3fxabkezMPiE/edit#gid=0) (MB numbers) to use for all the `client` tags of a project. If you see your project missing, please contact the Director of Infrastructure in Slack.
 
 Note that both the `key` and the `value` of AWS tags are *case-sensitive*. Keep keys and values as all lower-case, except when using an acronym.
 


### PR DESCRIPTION
I'm working on https://github.com/18F/writing-lab/issues/138 in incremental chunks, rather than in one big pull request, so that you all can give me feedback if I head in the wrong direction. Here's a chunk! Some changes:

* The ATO homepage doesn't need a two-step guide (1. walkthrough 2. checklist) since the walkthrough explains that you'll need to do the checklist.
* The Before You Ship homepage should just link to the ATO main page - not the main page and the "tips" page, since the ATO main page should guide you to the right things to read.
* Small precision things: the "DevOps" repo is now the "Infrastructure" repo, "about.yml" is really ".about.yml", "FISMA Medium" is officially called "FISMA Moderate".
* The team doesn't usually talk about the "Director of Delivery Architecture" - we usually talk about the ["Director of Infrastructure"](https://handbook.18f.gov/intro-to-18f-infrastructure/), so it's more clear to use that phrasing.
* [18F content guide](https://pages.18f.gov/content-guide/) style edits: we use contractions for a friendly tone, we use em-dashes instead of dashes, we capitalize the first items in a list, etc.
* I revised the first part of the walkthrough page with more precise language to make it easier to understand. This should be checked to make sure I'm maintaining the right meanings.