### PR TITLE
Organizing sidebar and revising homepage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,9 +32,43 @@ logoalt: 18F logo
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:
-- text: Introduction
+- text: Overview
   url: ''
   internal: true
+- text: ATOs
+  url: ato/
+  internal: true
+  children:
+  - text: Background
+    url: background/
+    internal: true
+  - text: Types
+    url: types/
+    internal: true
+  - text: Walkthrough
+    url: walkthrough/
+    internal: true
+  - text: Checklist
+    url: checklist/
+    internal: true
+  - text: Categorize
+    url: categorize/
+    internal: true
+  - text: Levels
+    url: levels/
+    internal: true
+  - text: Controls
+    url: controls/
+    internal: true
+  - text: System Security Plan
+    url: ssp/
+    internal: true
+  - text: System Ownership
+    url: ownership/
+    internal: true
+  - text: Tips
+    url: tips/
+    internal: true
 - text: Security
   url: security/
   internal: true
@@ -54,39 +88,21 @@ navigation:
   - text: Frameworks
     url: frameworks/
     internal: true
-- text: ATOs
-  url: ato/
+- text: Infrastructure
+  url: infrastructure/
   internal: true
   children:
-  - text: Background
-    url: background/
+  - text: Amazon Web Services
+    url: aws/
     internal: true
-  - text: Levels
-    url: levels/
+  - text: Good Production Practices
+    url: good-production-practices/
     internal: true
-  - text: Checklist
-    url: checklist/
+  - text: Common Questions
+    url: common-questions/
     internal: true
-  - text: Tips
-    url: tips/
-    internal: true
-  - text: System Security Plan
-    url: ssp/
-    internal: true
-  - text: Types
-    url: types/
-    internal: true
-  - text: Controls
-    url: controls/
-    internal: true
-  - text: System Ownership
-    url: ownership/
-    internal: true
-  - text: Walkthrough
-    url: walkthrough/
-    internal: true
-  - text: Categorize
-    url: categorize/
+  - text: Monitoring
+    url: monitoring/
     internal: true
 - text: Laws
   url: laws/
@@ -103,22 +119,6 @@ navigation:
     internal: true
   - text: SORN
     url: sorn/
-    internal: true
-- text: Infrastructure
-  url: infrastructure/
-  internal: true
-  children:
-  - text: Amazon Web Services
-    url: aws/
-    internal: true
-  - text: Good Production Practices
-    url: good-production-practices/
-    internal: true
-  - text: Common Questions
-    url: common-questions/
-    internal: true
-  - text: Monitoring
-    url: monitoring/
     internal: true
 
 repos:

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,21 +1,19 @@
 ---
-title: Introduction
+title: Your guide to launching software at 18F
 permalink: /
 ---
 
-The goal of this site is to provide 18F staff with the information they need to launch software. It's a mix of requirements and best practices for projects at 18F, which may or may not be applicable for other teams inside or outside of government.
+The goal of this site is to provide 18F staff with the information they need to launch software. It explains requirements and best practices for projects at 18F, which may or may not apply to other teams inside or outside of government.
 
-* **This list is:**
-    * A general guide to review early and often
-    * _Especially_ important when you're starting to consider a future project launch or feature release
-* **This list is not:**
-    * A last-minute pre-launch checklist, despite the "Before You Ship" title
+You need this if you're a product lead or technical lead, but since all project team members contribute to launches, everyone at 18F can benefit from reading it.
 
-Like with most things in 18F, this guide is a user-contributed work in progress. Let us know [how to improve it!](https://github.com/18F/before-you-ship/issues/new)
+**Read this guide early and often**, especially when you're starting to consider a future project launch or feature release. **This isn't a last-minute pre-launch checklist.**
+
+This page gives the big picture, and the left sidebar gives details about some of the key parts. Like most things at 18F, this guide is a user-contributed work in progress. Let us know [how to improve it](https://github.com/18F/before-you-ship/issues/new)!
 
 ### Compliance
 
-You need an Authority to Operate (ATO). Essentially, ATOs cover the important security reviews and approvals **required** for public government websites. They can take months (albeit rarely). You should review this [overview of ATOs](ato/) to start planning.
+Every project needs an Authority to Operate (ATO). ATOs cover the important security reviews and approvals **required** for public government websites. They can sometimes take months, so you should start this process very soon after a project begins. Review the [**overview of ATOs**](ato/) to start planning.
 
 ### Outreach
 
@@ -28,7 +26,7 @@ You need an Authority to Operate (ATO). Essentially, ATOs cover the important se
 ### Client expectations
 
 * Exactly how big of a splashy launch are you planning? Is POTUS announcing it? Have you decided on the level of spikes in traffic your budget supports? You should coordinate this with your engineers, client, and the Infrastructure Team.
-* Will your team need to work more than 40 hours in a week to support the launch? You should start the [comp time approvals process before launch, which is described in our handbook](https://github.com/18F/handbook/blob/staging/articles/5-training-and-professional-development/classes/benefits.md#comp-time). We take this seriously.
+* Will your team need to work more than 40 hours in a week to support the launch? You should start the [comp time approvals process before launch, which is described in our handbook](https://handbook.18f.gov/benefits/#heading-10). We take this seriously.
 * What will you do if something breaks? Have you talked to your client about their expectations of up time and their budget? 18F currently does not offer Service Level Agreements (SLAs), which normally include agreements about uptime and response time to downtime, but you should have an escalation protocol in place. Here is an example from the [betaFEC](https://beta.fec.gov) team.
 
     > 18F does not officially offer Service Level Agreements (SLAs), but we would still like to clarify expectations of up time for our client and users:
@@ -51,18 +49,17 @@ You need an Authority to Operate (ATO). Essentially, ATOs cover the important se
     * [CFPB's open source checklist](https://github.com/cfpb/open-source-project-template/blob/master/opensource-checklist.md)
     * _Ask #wg-opensource if you have questions._
 * Make sure you have all the social media metadata and preview images.
-* Set up [security scanning](security/scanning/).
-* Look through the [framework-specific guides](security/frameworks/).
 
-### Operations
+### Security and operations
 
+* Review the [**security best practices**](security/), including [scanning](security/scanning/) and the [framework-specific guides](security/frameworks/).
 * Is [SSL](https://github.com/18f/https) enabled for everything?
     * Do all of your URLs start with `https://`?
     * Does visiting your site with `http://` redirect to `https://`?
+* Review the [**infrastructure best practices**](infrastructure/).
 * Reach out to the #infrastructure team at least a month in advance of launch to give them a heads up.
-* Take a look at the [infrastructure best practices](infrastructure/).
 
-## Also consider
+### Also consider
 
 * Are you addressing user needs? How will you validate this a few months after launch?
 * Do you have a metrics and measurements strategy? Who owns this?


### PR DESCRIPTION
Here's another incremental edit to help address https://github.com/18F/writing-lab/issues/138! In order to help people find the ATO and security information they need to read, I did some work sorting out the overall organization of the guide.

* I rearranged the items in the left sidebar to reflect the order of the content on these pages, especially for the ATO section - those items are now more or less in the order that they're described by the ATO overview and walkthrough.
* I renamed the homepage title from "Introduction" to "Your guide to launching software at 18F", to help readers recognize that they're in the right place (since "Before you ship" is a bit vague). In the left sidebar, I changed "Introduction" to "Overview" (since the homepage isn't just an introduction to shipping, it's an overall guide to shipping). Might change that again later if I come up with something better.
* I rewrote the intro to make it easier to read and more specific about who the audience is.
* I clarified the guide's links to the ATO, security, and infrastructure sections.
* I updated a broken handbook link, yay!