### PR TITLE
remove requirement of using 18f-pages-internal branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,6 @@ For each task to complete "before you ship", there should be a clear indication 
     * Where to file a GitHub issue
     * A specific person (if necessary)
 
-## Pull requests
-
-Please submit all pull requests to the `18f-pages-internal` branch first. The repository's maintainers will take it from there, and accept, modify, or reject the request. Maintainers will also move the change to `18f-pages`, the production branch.
-
 ## Public domain
 
 This project is in the public domain within the United States, and


### PR DESCRIPTION
Per a conversation with @NoahKunin today (or yesterday?), since this information isn't churning as much as it was, we can remove the step of needing all public deploys to go through him. After merge:

* [ ] Delete `18f-pages-internal` branch
* [ ] Change the default branch to be `18f-pages`
* [ ] Profit