### PR TITLE
Noting standard 18F Pages site install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@ This is the source repository for the 18F [Before You Ship](https://pages.18f.go
 
 ### Development
 
-To run a local copy, clone this repository and run these commands:
-
-```
-bundle install
-./go serve
-```
-
+See the Usage section of our [Contributing guidelines](https://github.com/18F/before-you-ship/blob/18f-pages/CONTRIBUTING.md#usage
+). 
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This is the source repository for the 18F [Before You Ship](https://pages.18f.gov/before-you-ship/) guide. The [ATO](https://pages.18f.gov/before-you-ship/ato/)-related sections of this site are maintained by the [Compliance Toolkit](https://github.com/18F/compliance-toolkit) team.
 
+### Development
+
+To run a local copy, clone this repository and run these commands:
+
+```
+bundle install
+./go serve
+```
+
 ### Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):


### PR DESCRIPTION
To help people make changes even if they aren't already familiar with 18F Pages.
