### PR TITLE
Link to production ready page on docs.cloud.gov

### DIFF
--- a/_pages/infrastructure/good-production-practices.md
+++ b/_pages/infrastructure/good-production-practices.md
@@ -3,7 +3,9 @@ title: Good Production Practices
 parent: Infrastructure
 ---
 
-Below is a list of "good" production ops practices, which product and tech leads should consider early in their development and review as part of any major launch. Items in **bold** are considered must-haves. We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start.
+Below is a list of "good" production ops practices, which product and tech leads should consider early in their development and review as part of any major launch. Items in **bold** are considered must-haves.
+
+We will be adding more documentation about how to achieve these within 18F's infrastructure soon, but [docs.cloud.gov](https://docs.cloud.gov/) is a good place to start. It includes a [guide to production-ready apps on cloud.gov](https://docs.cloud.gov/apps/production-ready/) with tips about how to implement relevant practices.
 
 ### Backups
 


### PR DESCRIPTION
A simple change to point to https://docs.cloud.gov/apps/production-ready/ in case it's helpful for people running into this page.