### PR TITLE
remove QuantifiedCode from list of services

### DIFF
--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -18,7 +18,6 @@ Service | Languages/frameworks | Dependency analysis | Code analysis
 [Code Climate](https://codeclimate.com/) | Ruby, JS, Python | Ruby and Node (on `push` only) | Rails, Node, and Ember
 [Gemnasium](https://gemnasium.com/) | Ruby, Node, Python, PHP | Y | N
 [Hakiri](https://hakiri.io/) | Ruby | Y | Rails only
-[QuantifiedCode](https://www.quantifiedcode.com/) | Python | N | Y
 
 Code analysis can be run locally with the following open source tools. These tools provide results similar (and in some cases, identical) to the hosted services above.
 


### PR DESCRIPTION
Per @cmc333333 in https://github.com/18F/Infrastructure/issues/651#issuecomment-242495094. Confirmed on [their site](https://www.quantifiedcode.com/) that it's shutting down:

![screen shot 2016-08-25 at 4 44 12 pm](https://cloud.githubusercontent.com/assets/86842/17985291/2eb269d4-6ae3-11e6-9b14-eee4330d5b8c.png)
