### PR TITLE
Update chandika links.

### DIFF
--- a/_pages/infrastructure/aws.md
+++ b/_pages/infrastructure/aws.md
@@ -25,7 +25,7 @@ In order to ensure systems deployed to AWS are robust and reliable, and to ensur
 
 ### Permissions
 
-Anyone in 18F can get access to the AWS [sandbox account](../sandbox). However only the 18F infrastructure team has login credentials to our production 18F account, and they are only used for debugging and incident management purposes. All systems are deployed using a continuous delivery service from scripts stored in version control, and registered in [Chandika](https://chandika.apps.cloud.gov).
+Anyone in 18F can get access to the AWS [sandbox account](../sandbox). However only the 18F infrastructure team has login credentials to our production 18F account, and they are only used for debugging and incident management purposes. All systems are deployed using a continuous delivery service from scripts stored in version control, and registered in [Chandika](https://chandika.fr.cloud.gov).
 
 This means:
 

--- a/_pages/infrastructure/sandbox.md
+++ b/_pages/infrastructure/sandbox.md
@@ -32,7 +32,7 @@ be deleted: all sandbox users should [subscribe to receive this email](https://g
 
 You can however protect resources from deletion by following two
 steps. First, register the system you are working on in
-[Chandika](https://chandika.apps.cloud.gov). When creating the system,
+[Chandika](https://chandika.fr.cloud.gov). When creating the system,
 make sure you enter a short, unique name for your system in the field
 `Infrastructure Tag`. Second, make sure you tag all resources you create
 in the AWS sandbox with the tag `Project=<system_infrastructure_tag>`,
@@ -59,7 +59,7 @@ Thus in order to keep our rates low, it's extremely important to bill infrastruc
 including non-production costs, to agency partners wherever
 possible. If the work you are doing is in support of a project which has an
 inter-agency agreement (IAA), you *must* create an entry for your
-system in [Chandika](https://chandika.apps.cloud.gov), including the
+system in [Chandika](https://chandika.fr.cloud.gov), including the
 Tock project code and the infrastructure tag you will be using, and tag
 any AWS resources accordingly so we can bill these costs to our partner agencies.
 


### PR DESCRIPTION
Looks like chandika has moved from chandika.apps.cloud.gov to chandika.fr.cloud.gov.