### PR TITLE
expand the ATO checklist

### DIFF
--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -1,10 +1,10 @@
-* **Main repository:** <url>
+* **Main repository:** [url]
 * **Running libraries:**
-    * <url>
+    * [url]
     * ...
-* **Site:** <url>
-* **Product manager:** @<username>
-* **Technical point of contact:** @<username>
+* **Site:** [url]
+* **Product manager:** @[username]
+* **Technical point of contact:** @[username]
 
 ## TODOs
 

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -1,41 +1,62 @@
 * **Main repository:** [url]
-* **Running libraries:**
-    * [url]
-    * ...
 * **Site:** [url]
 * **Product manager:** @[username]
 * **Technical point of contact:** @[username]
+* **Infrastructure Lead:** @[username]
+* **ATO folder:** [url]
 
 ## TODOs
 
-### Project team
+### ATO Sprint prerequisites
 
-Many of these tasks can be done in parallel. This is just a suggestion of priority.
+#### Infrastructure lead
 
+- [ ] Determine the [impact level](https://pages.18f.gov/before-you-ship/ato/levels/)
+- [ ] Assign the appropriate labels to this issue
+- [ ] Create an "ATO folder" for the project as a sub-folder of [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". Link to it above.
+- [ ] Add templates to the ATO folder
+    - [ ] Rules of Engagement (RoE)
+    - [ ] System Security Plan
+    - [ ] Project Plan
+
+#### Project team
+
+##### Technical
+
+- [ ] Ensure that a staging environment is fully set up.
+    * This should be as production-like as possible.
 - [ ] [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#downtime)
     * [ ] [Error alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors)
-- [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository
-- [ ] Create a sub-folder in [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". This will be knows as the "ATO Folder". Link it here.
-- [ ] Security scans (make this a link to the ATO Folder where you put a copy of the security scan results)
+- [ ] Perform security scans, and put the results (or a link to them) in the ATO folder.
     * [ ] Set up [static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/) service
         * [ ] Add service badges to the README
     * [ ] [Perform dynamic vulnerability scanning](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/)
         * [ ] Resolve any visible security issues, re-running the scan as needed
         * [ ] Add the issue-free scan report or [documentation about false positives](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/#caveats) to the ATO folder.
+- [ ] If this is a new system, add a prominent [`Beta`](https://18f.gsa.gov/dashboard/stages/) label to the site
+- [ ] Ensure the staging environment has sufficient capacity to withstand the testing
+    * The testing tools create very heavy usage and traffic.
+
+##### Writing
+
+- [ ] Fill out the Rules of Engagement (RoE)
+    * Use staging URLs, rather than production ones.
+- [ ] Fill out the Project Plan
+- [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository
 - [ ] [Update relevant documentation](https://pages.18f.gov/before-you-ship/ato/tips/), primarily the README
-- [ ] If this will be a new ATO, add a prominent [`Beta`](https://18f.gsa.gov/dashboard/stages/) label to any currently-running sites
 - [ ] Add a [System Security Plan yml](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
-- [ ] Add a System Security Plan Google doc to the ATO folder (talk to your Infrastructure Lead for a template)
 - [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
 - [ ] [Implement the controls](https://pages.18f.gov/before-you-ship/ato/walkthrough/#step-3--implement-the-controls)
-- [ ] Add a Rules of Engagement (RoE) Google doc to the ATO folder (talk to your Infrastructure Lead for a template)
-- [ ] Ensure system environment referenced in the RoE for security testing is ready for testing. No production links should be included in the RoE so as to avoid any testing happening on production (which could lead to downtime).
-- [ ] Add a Project Plan Google doc to the ATO folder (talk to your Infrastructure Lead for a template)
 
-### Authorizing Official
+### Mid-Sprint
 
-* [ ] Final review and risk acceptance signatures (ATO)
+* [ ] Penetration test conducted - @[tester]
+
+### Post-Sprint
+
+* [ ] Final review and risk acceptance signatures (ATO) - @NoahKunin
+* [ ] Remove the `Beta` label from the site
 
 ---
 

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -9,12 +9,14 @@
 
 ### ATO Sprint prerequisites
 
-#### Infrastructure lead
+#### Infrastructure Lead
 
-- [ ] Determine the [impact level](https://pages.18f.gov/before-you-ship/ato/levels/)
-- [ ] Assign the appropriate labels to this issue
+- [ ] Set up an ATO intro meeting with the team.
+- [ ] Determine the [impact level](https://pages.18f.gov/before-you-ship/ato/levels/).
+- [ ] Add this issue to the `Backlog` of [the ATO Kanban board](https://github.com/18F/Infrastructure/projects/1).
+- [ ] Assign the appropriate labels to this issue.
 - [ ] Create an "ATO folder" for the project as a sub-folder of [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". Link to it above.
-- [ ] Add templates to the ATO folder
+- [ ] Add templates to the ATO folder.
     - [ ] Rules of Engagement (RoE)
     - [ ] System Security Plan
     - [ ] Project Plan
@@ -31,6 +33,7 @@
 - [ ] Perform security scans, and put the results (or a link to them) in the ATO folder.
     * [ ] Set up [static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/) service
         * [ ] Add service badges to the README
+        * [ ] Put a point-in-time PDF of the scan results in the ATO folder
     * [ ] [Perform dynamic vulnerability scanning](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/)
         * [ ] Resolve any visible security issues, re-running the scan as needed
         * [ ] Add the issue-free scan report or [documentation about false positives](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/#caveats) to the ATO folder.
@@ -38,8 +41,9 @@
 - [ ] Ensure the staging environment has sufficient capacity to withstand the testing
     * The testing tools create very heavy usage and traffic.
 
-##### Writing
+##### Content
 
+- [ ] Create a [system diagram](https://pages.18f.gov/before-you-ship/ato/ssp/#systemnetwork-diagrams)
 - [ ] Fill out the Rules of Engagement (RoE)
     * Use staging URLs, rather than production ones.
 - [ ] Fill out the Project Plan
@@ -49,14 +53,23 @@
 - [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
 - [ ] [Implement the controls](https://pages.18f.gov/before-you-ship/ato/walkthrough/#step-3--implement-the-controls)
 
+### Documentation review
+
+1. [ ] Move this issue to the `Documentation review` column of [the ATO Kanban board](https://github.com/18F/Infrastructure/projects/1). - @[infrastructure lead]
+1. [ ] Schedule a documentation review session. - @[infrastructure lead]
+    * One or more follow-up sessions may be necessary.
+1. [ ] Fix any documentation issues identified in the session.
+
 ### Mid-Sprint
 
-* [ ] Penetration test conducted - @[tester]
+1. [ ] Penetration test conducted - @[tester]
+1. [ ] Create a Plan of Actions and Milestones (POAM) - @[tester]
 
 ### Post-Sprint
 
-* [ ] Final review and risk acceptance signatures (ATO) - @NoahKunin
-* [ ] Remove the `Beta` label from the site
+1. [ ] Fix any `Critical` or `High` vulnerabilities.
+1. [ ] Final review and risk acceptance signatures (ATO) - @NoahKunin
+1. [ ] Remove the `Beta` label from the site
 
 ---
 

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -8,22 +8,26 @@
 
 ## TODOs
 
-### ATO Sprint prerequisites
+### Phase 1: ATO Sprint prerequisites
+
+Everything in this section needs to be completed before the project will be scheduled for an ATO Sprint.
 
 #### Infrastructure Lead
 
-- [ ] Set up an ATO intro meeting with the team.
+- [ ] Set up an ATO intro meeting with the project team.
 - [ ] Determine the [impact level](https://pages.18f.gov/before-you-ship/ato/levels/).
+    * [ ] Confirm with @[Authorizing Official]
 - [ ] Add this issue to the `Backlog` of [the ATO Kanban board](https://github.com/18F/Infrastructure/projects/1).
 - [ ] Assign the appropriate labels to this issue.
 - [ ] Set up the project ATO folder.
-    - [ ] Create as a sub-folder of [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". Link to it above.
+    - [ ] [In the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing), go to `18F`/`OPP`/`PIF`, then `Work in progress`, and create a subfolder called in the format `<project> ATO - <duration> <level>`. Link to it as the `ATO folder` at the top of this issue.
     - [ ] Add Rules of Engagement (RoE) template
+        * Search [this page](https://insite.gsa.gov/portal/content/627238) for "Rules of Engagement (RoE) 90-Day LATO Penetration Test TEMPLATE", even if this isn't for a 90-day LATO.
     - [ ] Add [System Security Plan (SSP)](https://pages.18f.gov/before-you-ship/ato/ssp/) template
     - [ ] Add Project Plan template
-- [ ] Make a copy of the [notes doc template](https://docs.google.com/document/d/1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M/edit) in the [Sprinting Team folder](https://drive.google.com/open?id=1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M).
+- [ ] Make a copy of the [ATO Sprinting notes template](https://docs.google.com/document/d/1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M/edit) and save it in the [Sprinting Team folder](https://drive.google.com/open?id=1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M) with a title of `ATO Sprinting Team notes - <project>`.
     - [ ] Fill out the placeholders.
-    - [ ] Add link at the top of this issue.
+    - [ ] Link to it as the `Sprint notes` at the top of this issue.
 
 #### Project team
 
@@ -36,18 +40,20 @@
 - [ ] [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#downtime)
     * [ ] [Error & performance alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors--performance-problems)
-- [ ] Perform security scans, and put the results (or a link to them) in the ATO folder.
+- [ ] Perform security scans, and put the results (or a link to them) in the project's `ATO folder`.
     * [ ] Set up [static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/) service
         * [ ] Add service badges to the README
-        * [ ] Put a point-in-time PDF of the scan results in the ATO folder
+        * [ ] Put a point-in-time PDF of the scan results in the project's `ATO folder`.
     * [ ] [Perform dynamic vulnerability scanning](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/)
         * [ ] Resolve any visible security issues, re-running the scan as needed
-        * [ ] Add the issue-free scan report or [documentation about false positives](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/#caveats) to the ATO folder.
-- [ ] If this is a new system, add a prominent [`Beta`](https://18f.gsa.gov/dashboard/stages/) label to the site
-- [ ] Ensure the staging environment has sufficient capacity to withstand the testing
+        * [ ] Add the issue-free scan report or [documentation about false positives](https://pages.18f.gov/before-you-ship/security/dynamic-scanning/#caveats) to the project's ATO folder.
+- [ ] If this is a new system, add a prominent [`Beta`](https://18f.gsa.gov/dashboard/stages/) label to the site.
+- [ ] Ensure the staging environment has sufficient capacity to withstand the testing.
     * The testing tools create very heavy usage and traffic.
 
-##### Content
+##### Documentation
+
+...reading and writing.
 
 - [ ] Read the LATO guide<!-- unless not doing a LATO -->.
     * Search [this page](https://insite.gsa.gov/portal/content/627230) for "Lightweight Security Authorization Process".
@@ -60,7 +66,7 @@
 - [ ] Add a [System Security Plan YAML file](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
 - [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
 
-### Documentation review
+### Phase 2: Documentation review
 
 1. [ ] Move this issue to the `Documentation review` column of [the ATO Kanban board](https://github.com/18F/Infrastructure/projects/1). - @[infrastructure lead]
 1. [ ] Schedule a documentation review session. - @[infrastructure lead]
@@ -70,19 +76,20 @@
     * [ ] System Owner
     * [ ] GSA IT
 
-### Mid-Sprint
+### Phase 3: ATO Sprint
 
+1. [ ] Sprint started.
 1. [ ] Penetration test complete. - @[tester]
-    * [ ] Enhanced Scanning and Assessment Process (ESAP) document added to ATO folder
-1. [ ] Put all findings in project's issue tracker.
-1. [ ] Fix any `Critical` or `High` vulnerabilities.
-    * This needs to be done before the ATO can be issued, but not necessarily before the end of the sprint.
+    * [ ] Enhanced Scanning and Assessment Process (ESAP) document added to ATO folder - @[tester]
+1. [ ] Put all vulnerabilities from the ESAP in the project's issue tracker.
+1. [ ] Fix any `Critical` or `High` vulnerabilities from the ESAP.
+    * This needs to be done before the ATO can be issued, though not necessarily before the end of the sprint.
 
-### Post-Sprint
+### Phase 4: Post-Sprint
 
 1. [ ] [Controls](https://pages.18f.gov/before-you-ship/ato/controls/) tested - @[GSA IT representative]
 1. [ ] Create a Plan of Actions and Milestones (POAM). - @[GSA IT representative]
-1. [ ] Final review and risk acceptance signatures (issue the ATO) - @NoahKunin
+1. [ ] Final review and risk acceptance signatures (issue the ATO) - @[Authorizing Official]
 1. [ ] Remove the `Beta` label from the site.
 1. [ ] Fix all `Moderate` vulnerabilities - due [30 days after ATO issued]
 1. [ ] Fix all `Low` vulnerabilities - due [60 days after ATO issued]

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -35,7 +35,7 @@
     * This should be as [production](https://pages.18f.gov/before-you-ship/infrastructure/)-like as possible.
 - [ ] [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#downtime)
-    * [ ] [Error alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors)
+    * [ ] [Error & performance alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors--performance-problems)
 - [ ] Perform security scans, and put the results (or a link to them) in the ATO folder.
     * [ ] Set up [static analysis](https://pages.18f.gov/before-you-ship/security/static-analysis/) service
         * [ ] Add service badges to the README
@@ -59,7 +59,6 @@
 - [ ] [Update relevant documentation](https://pages.18f.gov/before-you-ship/ato/tips/), primarily the README
 - [ ] Add a [System Security Plan YAML file](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
 - [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
-- [ ] [Implement the controls](https://pages.18f.gov/before-you-ship/ato/walkthrough/#step-3--implement-the-controls)
 
 ### Documentation review
 

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -1,9 +1,10 @@
 * **Main repository:** [url]
 * **Site:** [url]
 * **Product manager:** @[username]
-* **Technical point of contact:** @[username]
+* **System Owner:** @[username of technical point of contact who will be the project representative in the Sprint]
 * **Infrastructure Lead:** @[username]
 * **ATO folder:** [url]
+* **Sprint notes:** [url]
 
 ## TODOs
 
@@ -15,18 +16,21 @@
 - [ ] Determine the [impact level](https://pages.18f.gov/before-you-ship/ato/levels/).
 - [ ] Add this issue to the `Backlog` of [the ATO Kanban board](https://github.com/18F/Infrastructure/projects/1).
 - [ ] Assign the appropriate labels to this issue.
-- [ ] Create an "ATO folder" for the project as a sub-folder of [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". Link to it above.
-- [ ] Add templates to the ATO folder.
-    - [ ] Rules of Engagement (RoE)
-    - [ ] System Security Plan
-    - [ ] Project Plan
+- [ ] Set up the project ATO folder.
+    - [ ] Create as a sub-folder of [the `ATOs` folder in Google Drive](https://drive.google.com/a/gsa.gov/folderview?id=0BynIxtx-CfkdckljM3BPSkdQT1U&usp=sharing) under 18F/OPP/PIF then "Work in progress". Link to it above.
+    - [ ] Add Rules of Engagement (RoE) template
+    - [ ] Add [System Security Plan (SSP)](https://pages.18f.gov/before-you-ship/ato/ssp/) template
+    - [ ] Add Project Plan template
+- [ ] Make a copy of the [notes doc template](https://docs.google.com/document/d/1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M/edit) in the [Sprinting Team folder](https://drive.google.com/open?id=1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M).
+    - [ ] Fill out the placeholders.
+    - [ ] Add link at the top of this issue.
 
 #### Project team
 
 ##### Technical
 
 - [ ] Ensure that a staging environment is fully set up.
-    * This should be as production-like as possible.
+    * This should be as [production](https://pages.18f.gov/before-you-ship/infrastructure/)-like as possible.
 - [ ] [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#downtime)
     * [ ] [Error alerts](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/#errors)
@@ -49,7 +53,7 @@
 - [ ] Fill out the Project Plan
 - [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository
 - [ ] [Update relevant documentation](https://pages.18f.gov/before-you-ship/ato/tips/), primarily the README
-- [ ] Add a [System Security Plan yml](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
+- [ ] Add a [System Security Plan YAML file](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
 - [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
 - [ ] [Implement the controls](https://pages.18f.gov/before-you-ship/ato/walkthrough/#step-3--implement-the-controls)
 
@@ -59,17 +63,26 @@
 1. [ ] Schedule a documentation review session. - @[infrastructure lead]
     * One or more follow-up sessions may be necessary.
 1. [ ] Fix any documentation issues identified in the session.
+1. [ ] RoE signed
+    * [ ] System Owner
+    * [ ] GSA IT
 
 ### Mid-Sprint
 
-1. [ ] Penetration test conducted - @[tester]
-1. [ ] Create a Plan of Actions and Milestones (POAM) - @[tester]
+1. [ ] Penetration test complete. - @[tester]
+    * [ ] Enhanced Scanning and Assessment Process (ESAP) document added to ATO folder
+1. [ ] Put all findings in project's issue tracker.
+1. [ ] Fix any `Critical` or `High` vulnerabilities.
+    * This needs to be done before the ATO can be issued, but not necessarily before the end of the sprint.
 
 ### Post-Sprint
 
-1. [ ] Fix any `Critical` or `High` vulnerabilities.
-1. [ ] Final review and risk acceptance signatures (ATO) - @NoahKunin
-1. [ ] Remove the `Beta` label from the site
+1. [ ] [Controls](https://pages.18f.gov/before-you-ship/ato/controls/) tested - @[GSA IT representative]
+1. [ ] Create a Plan of Actions and Milestones (POAM). - @[GSA IT representative]
+1. [ ] Final review and risk acceptance signatures (issue the ATO) - @NoahKunin
+1. [ ] Remove the `Beta` label from the site.
+1. [ ] Fix all `Moderate` vulnerabilities - due [30 days after ATO issued]
+1. [ ] Fix all `Low` vulnerabilities - due [60 days after ATO issued]
 
 ---
 

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -29,6 +29,8 @@
 
 ##### Technical
 
+- [ ] Enable [protected branches](https://help.github.com/articles/about-protected-branches/) for the project repositor(ies).
+    * Get admin access via #admins-github, if needed.
 - [ ] Ensure that a staging environment is fully set up.
     * This should be as [production](https://pages.18f.gov/before-you-ship/infrastructure/)-like as possible.
 - [ ] [Set up monitoring](https://pages.18f.gov/before-you-ship/infrastructure/monitoring/)
@@ -47,6 +49,8 @@
 
 ##### Content
 
+- [ ] Read the LATO guide<!-- unless not doing a LATO -->.
+    * Search [this page](https://insite.gsa.gov/portal/content/627230) for "Lightweight Security Authorization Process".
 - [ ] Create a [system diagram](https://pages.18f.gov/before-you-ship/ato/ssp/#systemnetwork-diagrams)
 - [ ] Fill out the Rules of Engagement (RoE)
     * Use staging URLs, rather than production ones.

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -5,7 +5,7 @@ navtitle: Checklist
 
 The ATO checklist helps you track progress towards a successful launch throughout your project. It is a formatted issue on GitHub, and is the canonical source of information for your path to launch.
 
-To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%3Cproject%3E+-+due+%3Cdeadline%3E) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md). Make sure to replace the placeholders at the top. Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker. After the Infrastructure issue is created, the Infrastructure Team will schedule a time to meet with you and discuss the ATO.
+To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%5Bproject%5D-+due+%5Bdeadline%5D) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md) as the body. Make sure to replace the placeholders (the things in `[square brackets]`). Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker. After the Infrastructure issue is created, the Infrastructure Team will schedule a time to meet with you and discuss the ATO.
 
 Make sure to:
 
@@ -20,4 +20,4 @@ You are welcome to ask any questions as comments in the issue or #infrastructure
 
 {% comment %} https://github.com/jekyll/jekyll/issues/1303#issuecomment-21067548 {% endcomment %}
 {% capture checklist_content %}{% include checklist.md %}{% endcapture %}
-{{ checklist_content | replace: '<', '&lt;' | replace: '>', '&gt;' | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' }}
+{{ checklist_content | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' }}

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -20,6 +20,9 @@ You are welcome to ask any questions as comments in the issue or #infrastructure
 
 ---
 
-{% comment %} https://github.com/jekyll/jekyll/issues/1303#issuecomment-21067548 {% endcomment %}
+{% comment %}
+  render the checklist, showing the checkboxes (as GitHub will) and making the links back to this site relative
+  https://github.com/jekyll/jekyll/issues/1303#issuecomment-21067548
+{% endcomment %}
 {% capture checklist_content %}{% include checklist.md %}{% endcapture %}
-{{ checklist_content | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' | replace: '1. [ ]', '1. <input type="checkbox" disabled>' }}
+{{ checklist_content | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' | replace: '1. [ ]', '1. <input type="checkbox" disabled>' | replace: 'https://pages.18f.gov/before-you-ship/', '../../' }}

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -5,7 +5,7 @@ navtitle: Checklist
 
 The ATO checklist helps you track progress towards a successful launch throughout your project. It is a formatted issue on GitHub, and is the canonical source of information for your path to launch.
 
-To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%5Bproject%5D-+due+%5Bdeadline%5D) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md) as the body. Make sure to replace the placeholders (the things in `[square brackets]`). Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker.
+To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%5Bproject%5D-+due+%5Bdeadline%5D) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md) as the body. Make sure to replace the placeholders (the things in `[square brackets]`). Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker. Unless otherwise specified, all tasks are the responsibility of the project team.
 
 The tasks are in suggested order of priority, though they can often be done in parallel. Note that **all of the prerequisite tasks need to be completed before your project will be scheduled for a sprint**.
 

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -22,4 +22,4 @@ You are welcome to ask any questions as comments in the issue or #infrastructure
 
 {% comment %} https://github.com/jekyll/jekyll/issues/1303#issuecomment-21067548 {% endcomment %}
 {% capture checklist_content %}{% include checklist.md %}{% endcapture %}
-{{ checklist_content | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' }}
+{{ checklist_content | replace: '- [ ]', '* [ ]' | replace: '* [ ]', '* <input type="checkbox" disabled>' | replace: '1. [ ]', '1. <input type="checkbox" disabled>' }}

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -5,7 +5,9 @@ navtitle: Checklist
 
 The ATO checklist helps you track progress towards a successful launch throughout your project. It is a formatted issue on GitHub, and is the canonical source of information for your path to launch.
 
-To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%5Bproject%5D-+due+%5Bdeadline%5D) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md) as the body. Make sure to replace the placeholders (the things in `[square brackets]`). Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker. After the Infrastructure issue is created, the Infrastructure Team will schedule a time to meet with you and discuss the ATO.
+To start the security clearance process, [create an issue in the Infrastructure repository](https://github.com/18F/Infrastructure/issues/new?title=ATO+for+%5Bproject%5D-+due+%5Bdeadline%5D) using [this template](https://raw.githubusercontent.com/18F/before-you-ship/master/_includes/checklist.md) as the body. Make sure to replace the placeholders (the things in `[square brackets]`). Feel free to add a username after each task to assign it, and/or make corresponding items in your issue tracker.
+
+The tasks are in suggested order of priority, though they can often be done in parallel. Note that **all of the prerequisite tasks need to be completed before your project will be scheduled for a sprint**.
 
 Make sure to:
 


### PR DESCRIPTION
This pull request adds a bunch of items to the checklist, including new items to reflect what happens around and during the Sprint, as well as detailed tasks that should have been in there even before the Sprints were implemented. I recommend reviewing using the [rich diff](https://github.com/blog/1784-rendered-prose-diffs).

* Addresses parts of
    * https://github.com/18F/before-you-ship/issues/57
    * https://github.com/18F/before-you-ship/issues/191
    * https://github.com/18F/before-you-ship/issues/255
    * https://github.com/18F/before-you-ship/issues/259
* Closes https://github.com/18F/before-you-ship/issues/182.
* Closes https://github.com/18F/before-you-ship/issues/262.
* Closes https://github.com/18F/before-you-ship/issues/263.
* Closes https://github.com/18F/before-you-ship/issues/265.