### PR TITLE
deprecate the system-security-plan.yml

### DIFF
--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -24,7 +24,9 @@ Everything in this section needs to be completed before the project will be sche
     - [ ] Add Rules of Engagement (RoE) template
         * Search [this page](https://insite.gsa.gov/portal/content/627238) for "Rules of Engagement (RoE) 90-Day LATO Penetration Test TEMPLATE", even if this isn't for a 90-day LATO.
     - [ ] Add [System Security Plan (SSP)](https://pages.18f.gov/before-you-ship/ato/ssp/) template
+        * For Low systems on cloud.gov, use [this template](https://docs.google.com/a/gsa.gov/document/d/1tVbH39TFfvSaBbjWfLaR3GLOuvsLuhLFJ75xKowEV5c/edit?usp=sharing)
     - [ ] Add Project Plan template
+        * Search [this page](https://insite.gsa.gov/portal/content/627238) for "One Year LATO Project Plan Template", even if this isn't for a one-year LATO.
 - [ ] Make a copy of the [ATO Sprinting notes template](https://docs.google.com/document/d/1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M/edit) and save it in the [Sprinting Team folder](https://drive.google.com/open?id=1EdcNyE1kkQve3tHyiV1QIRWNOBlTeh33lAbX0h4h18M) with a title of `ATO Sprinting Team notes - <project>`.
     - [ ] Fill out the placeholders.
     - [ ] Link to it as the `Sprint notes` at the top of this issue.
@@ -63,8 +65,8 @@ Everything in this section needs to be completed before the project will be sche
 - [ ] Fill out the Project Plan
 - [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository
 - [ ] [Update relevant documentation](https://pages.18f.gov/before-you-ship/ato/tips/), primarily the README
-- [ ] Add a [System Security Plan YAML file](https://pages.18f.gov/before-you-ship/ato/ssp/#template) to the repository
-- [ ] [Set up Compliance Masonry documentation](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
+- [ ] Fill out the System Security Plan (SSP)
+    * Your Infrastructure Lead will tell you if you should [do this via Compliance Masonry](https://github.com/18F/cg-compliance#starting-ato-documentation-for-cloudgov-applications)
 
 ### Phase 2: Documentation review
 

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -67,7 +67,7 @@ There are several ways to ensure that your system remains compliant:
 
 * Act on any security notifications from your [static analysis](../security/static-analysis/).
 * Act on any security notifications from your [automated vulnerability scanning](../security/dynamic-scanning/#automated-scanning).
-* Keep your `about.yml`, `system-security-plan.yml`, and security-related documentation up-to-date.
+* Keep your `about.yml`, a copy of your System Security Plan, and any other architecture/security-related documentation up-to-date.
 
 ### System changes that may require a new ATO
 

--- a/_pages/ato/ssp.md
+++ b/_pages/ato/ssp.md
@@ -8,7 +8,7 @@ As described in [the NIST guide](http://csrc.nist.gov/publications/nistpubs/800-
 
 The system security plan (SSP) is a long Google Doc. 18F is actively working on a tool to generate them called [Compliance Masonry](https://github.com/opencontrol/compliance-masonry), which uses a machine-readable format for which template is below. For now, the Google Docs are the canonical versions of the SSP.
 
-### System/Network Diagrams
+### System/network diagrams
 
 One of the requirements for an SSP is to include a network diagram for your system. It is helpful to create this diagram as a Google Drawing so that your Infrastructure Lead and AO can edit it as needed during the ATO assessment process.
 
@@ -21,87 +21,3 @@ A few example diagrams can be found below:
 1. [A simple application running on cloud.gov](https://docs.google.com/drawings/d/1nwclBJQfbuzsnGOqe88VukQl3uiH1Jfa4c0FT1Cq43I/edit)
 1. [A more complex application running on cloud.gov](https://docs.google.com/drawings/d/1k1wykk5PbLKSNJj8FyZbIlpX0D8r1q3-w-uRK_WWt9g/edit)
 1. [A complex application not running on cloud.gov](https://docs.google.com/drawings/d/10cH-OUB1NWzCI0v9LPzm7AXCfrHXNkDgnae-7hcUFu8/edit)
-
-### Template
-
-Add the following to your repository as `system-security-plan.yml`, with the information in the `<angle brackets>` filled in. Once added to your repository, it should be kept up-to-date as the project progresses.
-
-```yaml
----
-name: <project name>
-uniqueID: <MB number – see https://docs.google.com/spreadsheets/d/1v4QfXGaJVy9-CZ0n6cFLHGGs_5TL1l8uCh6ZyNYjMDk/edit#gid=2047916505>
-version: <application version>
-# descriptions:
-# https://18f.gsa.gov/dashboard/
-phase: <discovery|alpha|beta|live>
-# `D26 Civilian Operations` is most common for 18F projects.
-# http://csrc.nist.gov/publications/nistpubs/800-60-rev1/SP800-60_Vol1-Rev1.pdf#page=23
-information-types:
-- <Dxx + name>
-
-# https://pages.18f.gov/before-you-ship/ato/levels/
-confidentiality: <none|low|moderate|high>
-integrity: <low|moderate|high>
-availability: <low|moderate|high>
-security-baseline: <open data|low|moderate|high>
-
-system-type: <major|minor|general support>
-level-of-identity-assurance: <0 if no authentication, or a link to SSP of the forthcoming identity system>
-staff:
-  authorizing-official:
-    name: Noah Kunin
-    title: TTS Infrastructure Director
-    org: General Services Administration
-    unit: TTS
-    email: devops@gsa.gov
-  system-owner:
-    name: <developer's name>
-    title: System Owner
-    org: General Services Administration
-    unit: 18F
-    email: <developer's email>
-  system-management:
-    name: Noah Kunin
-    title: TTS Infrastructure Director
-    org: General Services Administration
-    unit: TTS
-    email: devops@gsa.gov
-  system-security-officer:
-    name: Noah Kunin
-    title: TTS Infrastructure Director
-    org: General Services Administration
-    unit: TTS
-    email: devops@gsa.gov
-  technical-lead:
-    name: <developer's name>
-    title: Technical Lead
-    org: General Services Administration
-    unit: 18F
-    email: <developer's email>
-leveraged-authorizations:
-- https://www.fedramp.gov/marketplace/compliant-systems/amazon-web-services-aws-eastwest-us-public-cloud/
-purpose: <link to README>
-components:
-- <link to item under https://18f.gsa.gov/dashboard/>
-- <links to repositories>
-
-# these will be the same unless your architecture is especially complex
-system-diagram: <link>
-network-diagram: <link>
-
-environments:
-- Cloud Foundry
-- Amazon Web Services East
-user-types:
-  developer:
-    functions:
-    - deployment
-    - engineering
-controls:
-- <links to your security documentation>
-```
-
-## Examples
-
-* [ATF eRegs](https://github.com/18F/atf-eregs/blob/master/system-security-plan.yml)
-* [Every Kid In a Park (EKIP) API](https://github.com/18F/ekip-api/blob/master/system-security-plan.yml)


### PR DESCRIPTION
Builds on https://github.com/18F/before-you-ship/pull/291. Closes https://github.com/18F/before-you-ship/issues/197.

While it's a little bit of a bummer to move away from machine-readable documentation, I don't think the `system-security-plan.yml` was adding a lot of value, or event really in use. Let's remove the overhead for now.