### PR TITLE
Remove markdown javascript language hint from gemnasium hack code block

### DIFF
--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -37,7 +37,7 @@ Unfortunately, Gemnasium struggles (as of 01/2017) to handle all of 18F's reposi
 1. Open the web developer console in your browser.
 1. Edit this text (replacing `18F/repo-name` for your repo) and execute it:
 
-    ```javascript
+    ```
     $('[name=submit_github_projects]').before('<input type="hidden" name="full_names[]" value="18F/repo-name" />').click()
     ```
 


### PR DESCRIPTION
Looks like whatever markdown renderer this uses doesn't properly handle code block language hints. Notice the spurious `javascript` shown in the screenshot below:

<img width="480" alt="screen shot 2017-04-13 at 11 01 54 am" src="https://cloud.githubusercontent.com/assets/697848/25013322/c7c7dd6a-2038-11e7-9c97-5c5eabe3abb1.png">
