### PR TITLE
Fix unclickable checklist links

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -10,3 +10,17 @@ img.inline {
 .anchorjs-link {
   border: none;
 }
+
+/* USWDS positions checkboxes absolutely and hides them in favor of a styled
+ * :before element. We need to show disabled input boxes on the checklist page
+ * so that people can copy a checklist from markdown to GH and get the boxes. */
+#checklist-preview ~ ul input[type="checkbox"] {
+  position: relative;
+  opacity: 1;
+  width: 1.8rem;
+  height: 1.8rem;
+  display: block;
+  margin: 0.3rem 0.6rem 0 0;
+  border-radius: 0.3rem;
+  float: left;
+}


### PR DESCRIPTION
As a result of upgrading `guides_style_18f` to use the USWDS, the disabled inputs on the checklist page made the links in their corresponding list items unclickable. This overrides those styles on the checklist page only, leaving the rest of the site reliant on the WDS default behavior. The checklist page looks like this now:

<img width="672" alt="screen shot 2017-05-05 at 10 14 26 am" src="https://cloud.githubusercontent.com/assets/509309/25754435/68b5a5a0-317c-11e7-9dae-138a0499e49f.png">
