### PR TITLE
update the static analysis page

### DIFF
--- a/_pages/security/dynamic-scanning.md
+++ b/_pages/security/dynamic-scanning.md
@@ -95,4 +95,4 @@ The [ZAP User Guide](https://github.com/zaproxy/zap-core-help/wiki) is phenomena
 
 The [OWASP Vulnerable Web Applications Directory](https://www.owasp.org/index.php/OWASP_Vulnerable_Web_Applications_Directory_Project#tab=Main) has a great list of (intentionally) vulnerable targets that are useful for testing the capability of ZAP.
 
-We are currently collecting best practices for using ZAP. If you have a particular approach, extension, or option that you find effective, let us know in #cloud-gov-highbar or [open an issue](https://github.com/18f/before-you-ship/issues/new)!
+We are currently collecting best practices for using ZAP. If you have a particular approach, extension, or option that you find effective, [open an issue](https://github.com/18f/before-you-ship/issues/new)!

--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -47,7 +47,7 @@ See also:
 
 #### [Rails](http://rubyonrails.org/)
 
-* Set up [static security analysis](../static-analysis/#rails).
+* Set up [static security analysis](../static-analysis/#recommendations-by-language).
 * Read through [Secure Rails](https://github.com/ankane/secure_rails).
 * If you need authorization, consider using the gems listed below. Use the linked instructions to ensure you have authorization applied to all appropriate controller actions.
     * [CanCanCan](https://github.com/CanCanCommunity/cancancan#4-lock-it-down)
@@ -60,7 +60,7 @@ More info:
 
 #### [Sinatra](http://www.sinatrarb.com/)/[Padrino](http://padrinorb.com/)
 
-* Set up [static security analysis](../static-analysis/#other-ruby-frameworks). We are currently seeking recommendations for this configuration.
+* Set up [static security analysis](../static-analysis/#recommendations-by-language). We are currently seeking recommendations for this configuration.
 * Ensure that [rack-protection](https://github.com/sinatra/rack-protection) and/or [SecureHeaders](https://github.com/twitter/secureheaders) is enabled and configured.
 
 More info:

--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -8,7 +8,7 @@ Organized by language.
 
 ### [Node.js](https://nodejs.org/)
 
-* See info on JavaScript [static security analysis](../static-analysis/#javascript)
+* See info on JavaScript [static security analysis](../static-analysis/#recommendations-by-language)
 
 #### [Express](https://expressjs.com/)
 
@@ -22,7 +22,7 @@ Organized by language.
 
 #### [Django](https://www.djangoproject.com/)
 
-* Set up [static security analysis](../static-analysis/#python).
+* Set up [static security analysis](../static-analysis/#recommendations-by-language).
 * Read through the official [deployment checklist](https://docs.djangoproject.com/en/stable/howto/deployment/checklist/).
 
 See also:
@@ -34,7 +34,7 @@ See also:
 
 #### [Flask](http://flask.pocoo.org/)
 
-* Set up [static security analysis](../static-analysis/#python)
+* Set up [static security analysis](../static-analysis/#recommendations-by-language)
 * Read through the [official security docs](http://flask.pocoo.org/docs/security/)
 * Consider using [Flask-Security](https://pythonhosted.org/Flask-Security/)
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -11,13 +11,19 @@ Static analysis is an important part of the development process, and is required
 
 There are tools for JS, Ruby, and Python, and you are encouraged to set up this scanning early on in the development cycle to prevent unexpected delays when it's time to get your ATO. Note that there are _many_ tools out there for doing code style linting, but this page is specifically security-focused.
 
-## Services
+## Recommendations by language
 
-Service | Dependency analysis | Code security analysis
---- | --- | --- | ---
-[Code Climate](https://codeclimate.com/) | [Ruby](https://docs.codeclimate.com/v1.0/docs/bundler-audit) and [Node](https://docs.codeclimate.com/v1.0/docs/nodesecurity) (on `push` only) | [Rails](https://docs.codeclimate.com/v1.0/docs/brakeman) and [Node](https://docs.codeclimate.com/v1.0/docs/eslint) (using [plugins](#javascript))
-[Gemnasium](#gemnasium) | [list](http://support.gemnasium.com/knowledgebase/articles/1162735-what-dependency-technologies-are-you-supporting) | N
-[Hakiri](https://hakiri.io/) | Ruby | Rails only
+Language | Dependency analysis | Code security analysis
+--- | --- | ---
+Go | none known | see [below](#go)
+JavaScript | [Code Climate](https://docs.codeclimate.com/v1.0/docs/nodesecurity) or [Gemnasium](#gemnasium) | see [below](#javascript)
+Python | [Gemnasium](#gemnasium) | see [below](#python)
+Ruby | [Code Climate](https://docs.codeclimate.com/v1.0/docs/bundler-audit) or [Gemnasium](#gemnasium) | [Code Climate](https://docs.codeclimate.com/v1.0/docs/brakeman) or [Hakiri](https://hakiri.io/)<br>_both Rails only_
+
+### Notes
+
+* Code Climate only scans when the code is `push`ed, meaning it won't catch any vulnerabilities if the code isn't being actively worked on.
+* Wherever the table says "see below", that means there is no service available for scanning. Therefore, the recommended tool(s) should be run in continuous integration. Alternatively, you can also look into [building a Code Climate engine](https://docs.codeclimate.com/docs/building-a-code-climate-engine).
 
 ### Gemnasium
 
@@ -52,7 +58,7 @@ Use one of the services above, which should support adding public repositories y
 
 ## Code analysis
 
-This is commonly referred to as "static analysis". Code analysis can be done by a [service](#services) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
+This is commonly referred to as "static analysis". Code analysis can be done by a [service](#recommendations-by-language) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
 
 ### Go
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -56,37 +56,15 @@ This is commonly referred to as "static analysis". Code analysis can be done by 
 
 ### JavaScript
 
-There are several tools available for running analysis on JS projects, but the most full featured seems to be [ESLint](http://eslint.org). ESLint doesn't offer security scanning out of the box, but it is pluggable and Mozilla has provided a set of rules that mimic the behavior of their now deprecated ScanJS. These rules are available on [github](https://github.com/mozfreddyb/eslint-plugin-scanjs-rules).
-
-To install:
-
-    $ npm install eslint-config-scanjs
-
-To scan, from your project directory:
-
-    $ eslint .
-
-If you have an existing `.eslintrc` file in your project root, you can instead download the file elsewhere and run:
-
-    $ eslint -c <PATH_TO_ESLINTRC> .
+Use [eslint-config-scanjs](https://github.com/mozfreddyb/eslint-config-scanjs).
 
 ### Python
 
-There are surprisingly few security-focused static code analyzers for Python. The best seems to be OpenStack's [Bandit](https://github.com/openstack/bandit).
-
-To install (preferably in a virtual environment):
-
-    $ pip install bandit
-
-Download the [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit) from the compliance-toolkit repo into your project root. It will be automatically detected when you run Bandit.
-
-To scan, from your project directory:
-
-    $ bandit -r .
+Use [Bandit](https://github.com/openstack/bandit) with the provided [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit) in your project root.
 
 ### Config files
 
-Basic config files for the three static analysis tools can be found in the [compliance-toolkit repo](https://github.com/18F/compliance-toolkit). These currently are little more than the default settings, but the recommendations may change. If you find a test that you believe is invalid, file an issue in the repo and give a shout in #cloud-gov-highbar in Slack.
+Basic config files for the three static analysis tools can be found in the [compliance-toolkit repo](https://github.com/18F/compliance-toolkit). These currently are little more than the default settings, but the recommendations may change. If you find a test that you believe is invalid, file an issue in the repo.
 
 We are especially interested to know if you get lots of false positives. We believe the default config files will grow and evolve, but the most up-to-date versions will always be found in the repo.
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -21,7 +21,7 @@ Service | Dependency analysis | Code security analysis
 
 ### Gemnasium
 
-Gemnasium is used to scan your code for possible security issues and provides alerts for new issues that come to light.
+Gemnasium is used to scan your code for possible security issues and provides alerts for new issues that come to light. Their list of supported dependency technologies is [here](http://support.gemnasium.com/knowledgebase/articles/1162735-what-dependency-technologies-are-you-supporting).
 
 #### Setting up your account
 
@@ -54,18 +54,22 @@ Use one of the services above, which should support adding public repositories y
 
 This is commonly referred to as "static analysis". Code analysis can be done by a [service](#services) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
 
+### Go
+
+Use [Go Meta Linter](https://github.com/alecthomas/gometalinter), with the security-related [linters](https://github.com/alecthomas/gometalinter#supported-linters) (like [SafeSQL](https://github.com/stripe/safesql), if you're doing SQL queries) enabled.
+
 ### JavaScript
 
-Use [eslint-config-scanjs](https://github.com/mozfreddyb/eslint-config-scanjs).
+Try [eslint-config-scanjs](https://www.npmjs.com/package/eslint-config-scanjs) and [eslint-plugin-security](https://www.npmjs.com/package/eslint-plugin-security).
 
 ### Python
 
-Use [Bandit](https://github.com/openstack/bandit) with the provided [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit) in your project root.
+Use [Bandit](https://github.com/openstack/bandit) with the provided [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit) in your project root. There is also a work-in-progress [engine for Code Climate](https://github.com/18F/codeclimate-bandit).
 
 ### Config files
 
-Basic config files for the three static analysis tools can be found in the [compliance-toolkit repo](https://github.com/18F/compliance-toolkit). These currently are little more than the default settings, but the recommendations may change. If you find a test that you believe is invalid, file an issue in the repo.
+Basic config files for some static analysis tools can be found in the [compliance-toolkit repo](https://github.com/18F/compliance-toolkit). These currently are little more than the default settings, but the recommendations may change. If you find a test that you believe is invalid, file an issue in the repo.
 
 We are especially interested to know if you get lots of false positives. We believe the default config files will grow and evolve, but the most up-to-date versions will always be found in the repo.
 
-More advanced configuration options for all three tools can be found in their respective docs.
+More advanced configuration options for all the tools can be found in their respective docs.

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -52,7 +52,7 @@ Use one of the services above, which should support adding public repositories y
 
 ### Code analysis
 
-This is commonly referred to as "static analysis". Code analysis can be done by a [service](#services) (easiest), or within your existing continuous integration tool. Code analysis can be run locally with the following open source tools. These tools provide results similar (and in some cases, identical) to the hosted [services](#services) above.
+This is commonly referred to as "static analysis". Code analysis can be done by a [service](#services) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
 
 #### JavaScript
 
@@ -73,30 +73,6 @@ To scan, from your project directory:
 If you have an existing `.eslintrc` file in your project root, you can instead download the file elsewhere and run:
 
     $ eslint -c <PATH_TO_ESLINTRC> .
-
-#### Ruby
-
-##### Rails
-
-There are several free and paid services that will do static security analysis of Ruby code, but almost all of them appear to be wrappers around [Brakeman](https://github.com/presidentbeef/brakeman). As such, we suggest going straight to the source.
-
-To install:
-
-    $ gem install brakeman
-
-Download the [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/brakeman.yml) from the compliance-toolkit repo and copy it to ./config/brakeman.yml.
-
-To scan, from your project directory:
-
-    $ brakeman
-
-If you saved the config file elsewhere, you can also run:
-
-    $ brakeman -c <PATH_TO_BRAKEMAN_YML>
-
-##### Other Ruby Frameworks
-
-We do not have a recommended scanner for non-Rails frameworks. If there is a service or tool that works well, please [tell us about it](https://github.com/18F/before-you-ship/issues/new).
 
 #### Python
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -16,7 +16,7 @@ There are tools for JS, Ruby, and Python, and you are encouraged to set up this 
 Service | Dependency analysis | Code security analysis
 --- | --- | --- | ---
 [Code Climate](https://codeclimate.com/) | [Ruby](https://docs.codeclimate.com/v1.0/docs/bundler-audit) and [Node](https://docs.codeclimate.com/v1.0/docs/nodesecurity) (on `push` only) | [Rails](https://docs.codeclimate.com/v1.0/docs/brakeman) and [Node](https://docs.codeclimate.com/v1.0/docs/eslint) (using [plugins](#javascript))
-[Gemnasium](#gemnasium) | Ruby, Node, Python, PHP | N
+[Gemnasium](#gemnasium) | [list](http://support.gemnasium.com/knowledgebase/articles/1162735-what-dependency-technologies-are-you-supporting) | N
 [Hakiri](https://hakiri.io/) | Ruby | Rails only
 
 #### Gemnasium

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -15,10 +15,10 @@ There are tools for JS, Ruby, and Python, and you are encouraged to set up this 
 
 Language | Dependency analysis | Code security analysis
 --- | --- | ---
-Go | none known | see [below](#go)
-JavaScript | [Code Climate](https://docs.codeclimate.com/v1.0/docs/nodesecurity) or [Gemnasium](#gemnasium) | see [below](#javascript)
-Python | [Gemnasium](#gemnasium) | see [below](#python)
-Ruby | [Code Climate](https://docs.codeclimate.com/v1.0/docs/bundler-audit) or [Gemnasium](#gemnasium) | [Code Climate](https://docs.codeclimate.com/v1.0/docs/brakeman) or [Hakiri](https://hakiri.io/)<br>_both Rails only_
+Go | none known | [Go Meta Linter](https://github.com/alecthomas/gometalinter), with the security-related [linters](https://github.com/alecthomas/gometalinter#supported-linters) (like [SafeSQL](https://github.com/stripe/safesql), if you're doing SQL queries) enabled
+JavaScript | [Code Climate](https://docs.codeclimate.com/v1.0/docs/nodesecurity) or [Gemnasium](#gemnasium) | [eslint-config-scanjs](https://www.npmjs.com/package/eslint-config-scanjs) / [eslint-plugin-security](https://www.npmjs.com/package/eslint-plugin-security)
+Python | [Gemnasium](#gemnasium) | [Bandit](https://github.com/openstack/bandit) with the provided [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit); [engine for Code Climate](https://github.com/18F/codeclimate-bandit)
+Ruby | [Code Climate](https://docs.codeclimate.com/v1.0/docs/bundler-audit) or [Gemnasium](#gemnasium) | [Code Climate](https://docs.codeclimate.com/v1.0/docs/brakeman) or [Hakiri](https://hakiri.io/) - _Rails only_
 
 ### Notes
 
@@ -59,18 +59,6 @@ Use one of the services above, which should support adding public repositories y
 ## Code analysis
 
 This is commonly referred to as "static analysis". Code analysis can be done by a [service](#recommendations-by-language) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
-
-### Go
-
-Use [Go Meta Linter](https://github.com/alecthomas/gometalinter), with the security-related [linters](https://github.com/alecthomas/gometalinter#supported-linters) (like [SafeSQL](https://github.com/stripe/safesql), if you're doing SQL queries) enabled.
-
-### JavaScript
-
-Try [eslint-config-scanjs](https://www.npmjs.com/package/eslint-config-scanjs) and [eslint-plugin-security](https://www.npmjs.com/package/eslint-plugin-security).
-
-### Python
-
-Use [Bandit](https://github.com/openstack/bandit) with the provided [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.bandit) in your project root. There is also a work-in-progress [engine for Code Climate](https://github.com/18F/codeclimate-bandit).
 
 ### Config files
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -11,7 +11,7 @@ Static analysis is an important part of the development process, and is required
 
 There are tools for JS, Ruby, and Python, and you are encouraged to set up this scanning early on in the development cycle to prevent unexpected delays when it's time to get your ATO. Note that there are _many_ tools out there for doing code style linting, but this page is specifically security-focused.
 
-### Services
+## Services
 
 Service | Dependency analysis | Code security analysis
 --- | --- | --- | ---
@@ -19,18 +19,18 @@ Service | Dependency analysis | Code security analysis
 [Gemnasium](#gemnasium) | [list](http://support.gemnasium.com/knowledgebase/articles/1162735-what-dependency-technologies-are-you-supporting) | N
 [Hakiri](https://hakiri.io/) | Ruby | Rails only
 
-#### Gemnasium
+### Gemnasium
 
 Gemnasium is used to scan your code for possible security issues and provides alerts for new issues that come to light.
 
-##### Setting up your account
+#### Setting up your account
 
 1. [Sign into Gemnasium using your GitHub account.](https://gemnasium.com/login)
 1. Go to [your settings page](https://gemnasium.com/settings) and change it to use your work email, if it isn't already.
 1. Ask in [#infrastructure](https://gsa-tts.slack.com/messages/infrastructure/) to be invited to the devops@gsa.gov account.
 1. This provides you with access to the common dashboard for our projects. Make sure your project has multiple people with access to the gemnasium dashboard.
 
-##### Adding projects
+#### Adding projects
 
 Do not add repos to Gemnasium on your individual account.
 
@@ -46,15 +46,15 @@ Unfortunately, Gemnasium struggles (as of 01/2017) to handle all of 18F's reposi
 
 1. [Add the Gemnasium webhook to the GitHub repository.](http://support.gemnasium.com/knowledgebase/articles/829368-how-do-i-manually-create-a-webhook-on-github)
 
-### Dependency analysis
+## Dependency analysis
 
 Use one of the services above, which should support adding public repositories yourself. If you need scanning on a private repository, [file an issue in the Infrastructure repo](https://github.com/18F/Infrastructure/issues/new).
 
-### Code analysis
+## Code analysis
 
 This is commonly referred to as "static analysis". Code analysis can be done by a [service](#services) (recommended), or within your existing continuous integration tool. Additional configuration information available below.
 
-#### JavaScript
+### JavaScript
 
 There are several tools available for running analysis on JS projects, but the most full featured seems to be [ESLint](http://eslint.org). ESLint doesn't offer security scanning out of the box, but it is pluggable and Mozilla has provided a set of rules that mimic the behavior of their now deprecated ScanJS. These rules are available on [github](https://github.com/mozfreddyb/eslint-plugin-scanjs-rules).
 
@@ -70,7 +70,7 @@ If you have an existing `.eslintrc` file in your project root, you can instead d
 
     $ eslint -c <PATH_TO_ESLINTRC> .
 
-#### Python
+### Python
 
 There are surprisingly few security-focused static code analyzers for Python. The best seems to be OpenStack's [Bandit](https://github.com/openstack/bandit).
 
@@ -84,7 +84,7 @@ To scan, from your project directory:
 
     $ bandit -r .
 
-#### Config files
+### Config files
 
 Basic config files for the three static analysis tools can be found in the [compliance-toolkit repo](https://github.com/18F/compliance-toolkit). These currently are little more than the default settings, but the recommendations may change. If you find a test that you believe is invalid, file an issue in the repo and give a shout in #cloud-gov-highbar in Slack.
 
@@ -92,7 +92,7 @@ We are especially interested to know if you get lots of false positives. We beli
 
 More advanced configuration options for all three tools can be found in their respective docs.
 
-### Automation and future plans
+## Automation and future plans
 
 A representative from Code Climate recently gave a presentation at 18F about their new platform and [CLI](https://github.com/codeclimate/codeclimate). It acts as a wrapper around Docker images that can run any number of scans across projects, and many of the above tools are already available as [engines](https://docs.codeclimate.com/docs/list-of-engines) for the platform (Brakeman, bundler-audit, nsp, and ESLint). The lift to [create a new engine](http://blog.codeclimate.com/blog/2015/07/07/build-your-own-codeclimate-engine/) seems relatively low, so plans are in the works to [attempt to package Bandit as an engine](https://trello.com/c/PTL7z9uU/20-investigate-writing-a-code-climate-platform-engine-for-bandit) as well.
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -60,11 +60,7 @@ There are several tools available for running analysis on JS projects, but the m
 
 To install:
 
-    $ npm install --save-dev eslint
-    $ npm install --save-dev eslint-plugin-scanjs-rules
-    $ npm install --save-dev eslint-plugin-no-unsanitized
-
-Download the [config file](https://github.com/18F/compliance-toolkit/blob/master/configs/static/.eslintrc) from the compliance-toolkit repo and copy it to project root.
+    $ npm install eslint-config-scanjs
 
 To scan, from your project directory:
 

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -69,9 +69,3 @@ Basic config files for the three static analysis tools can be found in the [comp
 We are especially interested to know if you get lots of false positives. We believe the default config files will grow and evolve, but the most up-to-date versions will always be found in the repo.
 
 More advanced configuration options for all three tools can be found in their respective docs.
-
-## Automation and future plans
-
-A representative from Code Climate recently gave a presentation at 18F about their new platform and [CLI](https://github.com/codeclimate/codeclimate). It acts as a wrapper around Docker images that can run any number of scans across projects, and many of the above tools are already available as [engines](https://docs.codeclimate.com/docs/list-of-engines) for the platform (Brakeman, bundler-audit, nsp, and ESLint). The lift to [create a new engine](http://blog.codeclimate.com/blog/2015/07/07/build-your-own-codeclimate-engine/) seems relatively low, so plans are in the works to [attempt to package Bandit as an engine](https://trello.com/c/PTL7z9uU/20-investigate-writing-a-code-climate-platform-engine-for-bandit) as well.
-
-Using a single tool for all of our static security analysis would allow all projects and teams, regardless of language, to have the same workflow with minor config changes required. It also would allow for easy insertion into a project's existing CI workflow. We already have this advantage with dependency analysis.


### PR DESCRIPTION
**[Preview](https://federalist-proxy.app.cloud.gov/preview/18f/before-you-ship/deps/security/static-analysis/)**

In no particular order:

* Flipped the table to list available services by language, rather than the other way around.
    * This is more user-centered, as users will come in thinking "I'm using X language(s) - what do I do?"
* Add recommendation for Go - closes #213
* Remove references to channel that previously maintained the site
* Update recommended JavaScript scanning tools /cc #320
* Move the headings up a level (`h3`s to `h2`s, etc.)
* Remove instructions that can be found in the canonical source
   * Leaving them in, we risk them getting out-of-date