### PR TITLE
add page around logging

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,6 +92,9 @@ navigation:
   - text: Pinning Dependencies
     url: pinning-dependencies/
     internal: true
+  - text: Logging
+    url: logging/
+    internal: true
 - text: Laws
   url: laws/
   internal: true

--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -45,6 +45,7 @@ These tasks apply to every repository/application/hostname/language that is dire
 - [ ] [Set up monitoring](https://before-you-ship.18f.gov/infrastructure/monitoring/)
     * [ ] [Downtime alerts](https://before-you-ship.18f.gov/infrastructure/monitoring/#downtime)
     * [ ] [Error & performance alerts](https://before-you-ship.18f.gov/infrastructure/monitoring/#errors--performance-problems)
+- [ ] [Log required events](https://before-you-ship.18f.gov/infrastructure/logging/#what-to-log)
 - [ ] Perform security scans, and put the results (or a link to them) in the project's `ATO folder`.
     * [ ] Set up [dependency analysis](https://before-you-ship.18f.gov/security/static-analysis/) service
         * [ ] Add service badge to your README

--- a/_pages/infrastructure/good-production-practices.md
+++ b/_pages/infrastructure/good-production-practices.md
@@ -36,9 +36,7 @@ We will be adding more documentation about how to achieve these within 18F's inf
 
 ### Logs
 
-- **Logs are captured to durable storage before rotation**
-- **Logs with sensitive data are only available to appropriate people**
-- Logs can be browsed/drilled with low-latency (eg grepping not necessary)
+See [Logging](../logging/).
 
 ### Monitoring
 

--- a/_pages/infrastructure/logging.md
+++ b/_pages/infrastructure/logging.md
@@ -30,18 +30,11 @@ _This list comes from GSA’s [AU-2a](https://nvd.nist.gov/800-53/Rev4/control/a
 
 **Do not log [sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).**
 
-## Format
-
-- Important that the events are traceable back to the user that performed them (if possible), and when, so include things like:
-    - The user ID
-    - Timestamps, standardized in UTC
-- Log in JSON for easy searching in Kibana (which powers [logs.fr.cloud.gov](https://logs.fr.cloud.gov/)). Some tools that make this easier:
-    - Node: [bunyan](https://www.npmjs.com/package/bunyan)
-    - Python: [python-json-logger](https://github.com/madzak/python-json-logger)
-    - Ruby: [log_formatter](https://rubygems.org/gems/log_formatter/)
-
 ## Other notes
 
+- It's important that the events are traceable back to the user that performed them (if possible), and when, so include things like:
+    - The user ID
+    - Timestamps, standardized in UTC
 - Make sure the right logging is done in production (outside of debug/development mode)
     - [Example change for Django from the FEC project](https://github.com/18F/fec-cms/commit/39961b3ef84b1c2abe882959f15b9bc5d2e25bc8)
 - If not using cloud.gov, here are some things to think about:

--- a/_pages/infrastructure/logging.md
+++ b/_pages/infrastructure/logging.md
@@ -1,0 +1,50 @@
+---
+title: Logging
+parent: Infrastructure
+---
+
+When using cloud.gov, logs sent to standard out are automatically captured by [logs.fr.cloud.gov](https://logs.fr.cloud.gov). [More info.](https://cloud.gov/docs/apps/logs/)
+
+## What to log
+
+Things you are required to log:
+
+- Successful and unsuccessful account logon events
+- Account management events
+- Object access
+    - Examples: reading database records or files on disk
+- Policy change
+- Privilege functions
+- Process tracking
+- System events
+- For Web applications:
+    - All administrator activity
+    - Authentication checks
+    - Authorization checks
+    - Data deletions
+    - Data access
+    - Data changes
+    - Permission changes
+
+_This list comes from GSA’s [AU-2a](https://nvd.nist.gov/800-53/Rev4/control/au-2#Rev4Statements) Parameter Requirement - see the “Audit and Accountability” doc on [this page](https://insite.gsa.gov/portal/content/627230)._
+
+**Do not log [sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).**
+
+## Format
+
+- Important that the events are traceable back to the user that performed them (if possible), and when, so include things like:
+    - The user ID
+    - Timestamps, standardized in UTC
+- Log in JSON for easy searching in Kibana (which powers [logs.fr.cloud.gov](https://logs.fr.cloud.gov/)). Some tools that make this easier:
+    - Node: [bunyan](https://www.npmjs.com/package/bunyan)
+    - Python: [python-json-logger](https://github.com/madzak/python-json-logger)
+    - Ruby: [log_formatter](https://rubygems.org/gems/log_formatter/)
+
+## Other notes
+
+- Make sure the right logging is done in production (outside of debug/development mode)
+    - [Example change for Django from the FEC project](https://github.com/18F/fec-cms/commit/39961b3ef84b1c2abe882959f15b9bc5d2e25bc8)
+- If not using cloud.gov, here are some things to think about:
+    - Logs are captured to durable storage before rotation
+    - Logs with sensitive data are only available to appropriate people
+    - Logs can be browsed/drilled with low-latency (e.g. grepping not necessary)


### PR DESCRIPTION
Closes #284.

Adding a page with requirements and recommendations for logging, and linking there from the ATO checklist to ensure it's completed. Paired on this with @LindsayYoung and @LinuxBozo through the DevOps Guild.