### PR TITLE
install Bundler in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,5 @@ jobs:
       - image: starefossen/ruby-node:2-8
     steps:
       - checkout
+      - run: gem install bundler
       - run: ./go ci_test


### PR DESCRIPTION
Fixes the build. Bundler must have been installed by default before, but no longer.