### PR TITLE
Remove .about.yml tasks

### DIFF
--- a/_includes/checklist.md
+++ b/_includes/checklist.md
@@ -69,7 +69,6 @@ These tasks apply to every repository/application/hostname/language that is dire
 - [ ] Request a [privacy threshold analysis (PTA)](https://before-you-ship.18f.gov/privacy/)
 - [ ] Fill out the Rules of Engagement (RoE)
     * [Network diagram tips](https://before-you-ship.18f.gov/ato/ssp/#systemnetwork-diagrams)
-- [ ] Add an [`.about.yml`](https://github.com/18F/about_yml) for the main repository.
 - [ ] [Update relevant documentation](https://before-you-ship.18f.gov/ato/tips/), primarily the README.
 - [ ] [Fill out the System Security Plan (SSP).](https://before-you-ship.18f.gov/ato/ssp/)
 

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -100,7 +100,7 @@ There are several ways to ensure that your system remains compliant:
 
 * Act on any security notifications from your [static analysis](../security/static-analysis/).
 * Act on any security notifications from your [automated vulnerability scanning](../security/dynamic-scanning/#automated-scanning).
-* Keep your System Security Plan, and any other architecture/security-related documentation up-to-date.
+* Keep your System Security Plan (and any other architecture/security-related documentation) up-to-date.
 
 ### System changes that may require a new ATO
 

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -100,7 +100,7 @@ There are several ways to ensure that your system remains compliant:
 
 * Act on any security notifications from your [static analysis](../security/static-analysis/).
 * Act on any security notifications from your [automated vulnerability scanning](../security/dynamic-scanning/#automated-scanning).
-* Keep your `about.yml`, a copy of your System Security Plan, and any other architecture/security-related documentation up-to-date.
+* Keep your System Security Plan, and any other architecture/security-related documentation up-to-date.
 
 ### System changes that may require a new ATO
 

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -9,7 +9,7 @@ title: Tips
     * What does it accomplish by doing it?
 * For every release after your public launch, you should consider:
     * Accessibility reviews should be done for any changes.
-    * Do you need to update your GitHub documentation, or your `.about.yml`?
+    * Do you need to update your GitHub documentation?
 * The DigitalGov team at GSA has collected a list of [Requirements for Federal Websites and Digital Services](http://www.digitalgov.gov/resources/checklist-of-requirements-for-federal-digital-services/) that you should familiarize yourself with.
 * Exactly how big of a splashy launch are you planning? Is POTUS announcing it? Have you figured out what level of traffic you need to support? This should be coordinated between the engineers on your team, your client, and the Infrastructure Team.
 * Is your project accessible and [Section 508](../../laws/508/) compliant? The team will need to incorporate this throughout the project, but you'll also need to set up a review at least two weeks before launch.


### PR DESCRIPTION
`.about.yml` was an 18F-specific effort toward machine-readable data that no machines are reading anymore. For ATO purposes, the relevant information is in your System Security Plan. I recommend removing `.about.yml` from the ATO checklist and other tasks, so that we aren't asking people to do unnecessary work.

cc @andrewmaier @afeld 