### PR TITLE
Remove broken link to lifecycle guide

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -4,6 +4,6 @@ navtitle: Overview
 permalink: /
 ---
 
-The goal of this guide is to provide 18F staff with the information they need to launch software from a technical and compliance perspective. It explains requirements and best practices for projects at 18F, and the process of obtaining an ATO. **This site is a companion to [the Lifecycle section of 18F's Product Guide](https://product-guide.18f.gov/lifecycle-of-a-project/)**, which gives broader guidance.
+The goal of this guide is to provide 18F staff with the information they need to launch software from a technical and compliance perspective. It explains requirements and best practices for projects at 18F, and the process of obtaining an ATO.
 
 **Read this guide early and often**, especially when you're starting to consider a future project launch or feature release. **This isn't a last-minute pre-launch checklist.**


### PR DESCRIPTION
Fixes #382 

I think most of the Lifecycle section was removed from the product guide so there's nowhere to update the link to. Removing it instead. When the link was originally added, here's what the content looked like https://github.com/18F/product-guide/tree/15497b5120bac298f4b4dcecf4be5874f1d788a0/pages