### PR TITLE
update GSA LATO location

### DIFF
--- a/_includes/ato_checklist.md
+++ b/_includes/ato_checklist.md
@@ -65,7 +65,7 @@ These tasks apply to every repository/application/hostname/language that is dire
 
 - [ ] Read the [Overview](https://before-you-ship.18f.gov/) and [the ATO section (including sub-pages)](https://before-you-ship.18f.gov/ato/) of Before You Ship.
 - [ ] Read the LATO guide<!-- unless not doing a LATO -->.
-    * Search [this page](https://insite.gsa.gov/portal/content/627230) for "Lightweight Security Authorization Process".
+    * Search [this page](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/it-security-procedural-guides) for "Lightweight Security Authorization Guide".
 - [ ] Request a [privacy threshold analysis (PTA)](https://before-you-ship.18f.gov/privacy/)
 - [ ] Fill out the Rules of Engagement (RoE)
     * [Network diagram tips](https://before-you-ship.18f.gov/ato/ssp/#systemnetwork-diagrams)

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -88,7 +88,7 @@ The full list of data and functions in and of the system (in government parlance
 
 Your Infrastructure Lead will work with you to schedule and prioritize your system assessment. Once assessment starts, the first step is that the AO will review all the items in your ATO checklist including all the documents you generated.
 
-Then, for most systems, a team with members from the project team, your AO, your Infrastructure Lead, and the GSA OCISO will convene for at least a week as the [ATO Sprinting Team](https://docs.google.com/document/d/1bGOV_pp_BlAzZsoa2D5pnsinx3R2gVnaBdFvHkwv0ig/edit), and begin to follow the [Lightweight Security Authorization Process](https://insite.gsa.gov/portal/content/627230).
+Then, for most systems, a team with members from the project team, your AO, your Infrastructure Lead, and the GSA OCISO will convene for at least a week as the [ATO Sprinting Team](https://docs.google.com/document/d/1bGOV_pp_BlAzZsoa2D5pnsinx3R2gVnaBdFvHkwv0ig/edit), and begin to follow the [Lightweight Security Authorization Guide](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/it-security-procedural-guides).
 
 Folks from OCISO will conduct a penetration test on the system. Any penetration test findings deemed serious enough to prevent an ATO will need to be fixed right away to unblock the ATO process. They will also review the SSP document and test the control narratives. This testing and review process will take 1-2 weeks and should be the top priority for the project team at the time.
 

--- a/_pages/ato/types.md
+++ b/_pages/ato/types.md
@@ -3,7 +3,7 @@ title: Types of ATO
 navtitle: Types
 ---
 
-In most cases, the types of ATO that will be pursued for GSA systems are the *GSA Lightweight ATO (LATO)*. The GSA LATO process is described in a guide on [Insite](https://insite.gsa.gov/portal/content/627230) (search for "Lightweight Security Authorization Process" on that page). Systems that are under development must fulfill the requirements for [pre-assessment for internal government use](#conditions-for-pre-assessment).
+In most cases, the types of ATO that will be pursued for GSA systems are the *GSA Lightweight ATO (LATO)*. The GSA LATO process is described in a guide on [Insite](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/it-security-procedural-guides) (search for "Lightweight Security Authorization Guide" on that page). Systems that are under development must fulfill the requirements for [pre-assessment for internal government use](#conditions-for-pre-assessment).
 
 The GSA LATO is designed for **Low** and **Moderate** impact [level](../levels/) systems built using agile methods that run on top of cloud infrastructure which has already received an ATO (such as AWS, Azure, and [cloud.gov](https://cloud.gov)). It is "lightweight" because it represents a tailored subset of the hundreds of controls in NIST Special Publication (SP) 800-53.
 

--- a/_pages/infrastructure/logging.md
+++ b/_pages/infrastructure/logging.md
@@ -26,7 +26,7 @@ Things you are required to log:
     - Data changes
     - Permission changes
 
-_This list comes from GSA’s [AU-2a](https://nvd.nist.gov/800-53/Rev4/control/au-2#Rev4Statements) Parameter Requirement - see the “Audit and Accountability” doc on [this page](https://insite.gsa.gov/portal/content/627230)._
+_This list comes from GSA’s [AU-2a](https://nvd.nist.gov/800-53/Rev4/control/au-2#Rev4Statements) Parameter Requirement - see the “Audit and Accountability” doc on [this page](https://insite.gsa.gov/topics/information-technology/security-and-privacy/it-security/it-security-procedural-guides)._
 
 **Do not log [sensitive information](https://github.com/18F/open-source-policy/blob/master/practice.md#protecting-sensitive-information).**
 


### PR DESCRIPTION
Insight seems to have been re-organized, and thus the link and instructions on how to find the LATO procedure was wrong.  There was also an audit & accountability link that was on the same page that I found that needed changing.
