### PR TITLE
Enable stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,6 @@ jobs:
         days-before-stale: 45
         days-before-close: -1 # Don't close the PR/issue
         days-before-issue-stale: -1 # Ignore issues for now
-        debug-only: true #TODO remove me
         stale-pr-message: |
           Hello! I'm here to give this pull request a friendly nudge. It looks like this pull
           request hasn't been active in 45 days. If you're still working on this, then please


### PR DESCRIPTION
https://github.com/18F/tts-tech-portfolio/issues/1375

Remove the debug option, output looks like it's ignoring issues correctly.

Here's the log from the last run https://github.com/18F/before-you-ship/runs/2790858902?check_suite_focus=true
It identified the 4 open issues and correctly ignored them as stale because we've set `days-before-issue-stale: -1` and only want to mark PRs as stale for the moment. This appears to be working as expected, so let's enable it and continue to monitor.