### PR TITLE
Merge Lifecycle of a Launch into Handbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,4 @@ docker-compose up --build
 ```bash
 docker-compose run web bundle exec rake test
 ```
+

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,19 +2,7 @@ primary:
   - text: Overview
     href: /
   - text: Lifecycle of a Launch
-    links:
-      - text: ATOs
-        href: /ato/
-      - text: Checklist
-        href: /ato/checklist/
-      - text: Types
-        href: /ato/types/
-      - text: System Security Plan
-        href: /ato/ssp/
-      - text: Archer
-        href: /ato/archer/
-      - text: Tips
-        href: /ato/tips/
+    href: https://handbook.tts.gsa.gov/lifecycle
   - text: Security
     links:
       - text: General Security Standards

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,7 +2,19 @@ primary:
   - text: Overview
     href: /
   - text: Lifecycle of a Launch
-    href: https://handbook.tts.gsa.gov/lifecycle
+    links:
+      - text: ATOs
+        href: /ato/
+      - text: Checklist
+        href: /ato/checklist/
+      - text: Types
+        href: /ato/types/
+      - text: System Security Plan
+        href: /ato/ssp/
+      - text: Archer
+        href: /ato/archer/
+      - text: Tips
+        href: /ato/tips/
   - text: Security
     links:
       - text: General Security Standards

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -1,12 +1,13 @@
 ---
 title: Lifecycle of a Launch
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#atos
 ---
 
 <a href="https://atos.open-control.org/" class="usa-button">Learn about ATOs</a>
 
 ### Timeline
 
-ATO Sprints are staffed cross-divisionally by the GSA Office of the Chief Information Security Officer (OCISO) and TTS.
+ATO Sprints are staffed css-divisionally by the GSA Office of the Chief Information Security Officer (OCISO) and TTS.
 
 There are a few factors that will determine how long it takes a project to get an ATO. These map to [the checklist](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/ato.md), so might be helpful to open that up in another window and follow along.
 

--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -7,7 +7,7 @@ redirect_to: https://handbook.tts.gsa.gov/lifecycle/#atos
 
 ### Timeline
 
-ATO Sprints are staffed css-divisionally by the GSA Office of the Chief Information Security Officer (OCISO) and TTS.
+ATO Sprints are staffed cross-divisionally by the GSA Office of the Chief Information Security Officer (OCISO) and TTS.
 
 There are a few factors that will determine how long it takes a project to get an ATO. These map to [the checklist](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/ato.md), so might be helpful to open that up in another window and follow along.
 

--- a/_pages/ato/archer.md
+++ b/_pages/ato/archer.md
@@ -1,6 +1,7 @@
 ---
 title: RSA Archer
 navtitle: Archer
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#rsa-archer
 ---
 
 [RSA Archer](https://www.rsa.com/en-us/products/integrated-risk-management) is the canonical home for system compliance info at GSA. System Owners and Authorizing Officials should automatically have access, but additional read-only access can be [requested for "support staff"](https://docs.google.com/forms/d/e/1FAIpQLSccaOu1DpvnjQjw481iNsLDLEZp0hq3tovZv0xPjYNwnAbnlA/viewform).

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -1,6 +1,7 @@
 ---
 title: ATO Checklist
 navtitle: Checklist
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#ato-checklist
 ---
 
 The ATO checklist helps you track progress towards a successful launch throughout your project. It is a formatted issue on GitHub, and is the canonical source of information for your path to launch.

--- a/_pages/ato/ssp.md
+++ b/_pages/ato/ssp.md
@@ -1,5 +1,6 @@
 ---
 title: System Security Plan
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#system-security-plan
 ---
 
 As described in [the NIST guide](http://csrc.nist.gov/publications/nistpubs/800-18-Rev1/sp800-18-Rev1-final.pdf#page=7):

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -1,5 +1,6 @@
 ---
 title: Tips
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#tips
 ---
 
 - Is your project accessible and [Section 508](../../laws/508/) compliant? The team will need to incorporate this throughout the project, but you'll also need to set up a review at least two weeks before launch.

--- a/_pages/ato/types.md
+++ b/_pages/ato/types.md
@@ -1,6 +1,7 @@
 ---
 title: Types of ATO
 navtitle: Types
+redirect_to: https://handbook.tts.gsa.gov/lifecycle/#types-of-ato
 ---
 
 There are several different methods in obtaining a GSA Authorization as described in the policy IT Security Procedural Guide: Managing Enterprise Risk CIO-IT Security-06-30 in [Insite](https://insite.gsa.gov/cdnstatic/insite/Managing_Enterprise_Risk_%5BCIO_IT_Security_06-30_Rev_16%5D_10-03-2019docx.pdf)

--- a/_pages/security/mfa.md
+++ b/_pages/security/mfa.md
@@ -10,4 +10,4 @@ All TTS systems requiring authentication **must** use multiple factors. Examples
 - [**OMB Max**](https://max.gov/) - requires an Inter-Agency Agreement
 - [**Login.gov**](https://login.gov) - requires an Memorandum of Understanding for new agencies
 
-Systems in the [pre-assessment](../../ato/types/#conditions-for-pre-assessment) phase do not require MFA.
+Systems in the [pre-assessment](https://handbook.tts.gsa.gov/lifecycle/#conditions-for-pre-assessment) phase do not require MFA.


### PR DESCRIPTION
***
~WARNING: https://github.com/18F/handbook/pull/2526 must be merged first.~ It has been merged.
***
Closes #525 

This PR sets up a redirect link from the Lifecycle pages on BYS to the Lifecycle page on the Handbook.