### PR TITLE
Merge Security into Handbook

### DIFF
--- a/_pages/security.md
+++ b/_pages/security.md
@@ -1,6 +1,7 @@
 ---
 title: General Security Standards
 navtitle: Security
+redirect_to: https://handbook.tts.gsa.gov/security/
 ---
 
 In the Federal government, the principal law governing the security of information systems is the Federal Information Security Modernization Act (FISMA). For more information on FISMA, check out the [FISMA Implementation Project ](https://csrc.nist.gov/projects/risk-management), which will help you stay up to date and in the know about all things FISMA. If you're inclined to see TTS' intepretation of FISMA from a user-center approach, take a look at a previous project from the TTS Tech Portfolio and cloud.gov known as [FISMA Ready](https://github.com/fisma-ready/introduction).  

--- a/_pages/security/dynamic-scanning.md
+++ b/_pages/security/dynamic-scanning.md
@@ -1,6 +1,7 @@
 ---
 title: Dynamic Scanning
 parent: Security
+redirect_to: https://handbook.tts.gsa.gov/security/#dynamic-scanning
 ---
 
 In order for an application to get ATO, it needs to meet more than a minimum level of application security, so the application team needs to run [both static and dynamic security scans](../scanning/) and document good results. Running a "dynamic" scan means running a program that analyzes a live running application for common vulnerabilities.

--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -2,6 +2,7 @@
 title: Framework-Specific Security Guidelines
 navtitle: Frameworks
 parent: Security
+redirect_to: https://handbook.tts.gsa.gov/security/#frameworks
 ---
 
 Organized by language.

--- a/_pages/security/mfa.md
+++ b/_pages/security/mfa.md
@@ -1,6 +1,7 @@
 ---
 title: Multi-Factor Authentication
 parent: Security
+redirect_to: https://handbook.tts.gsa.gov/security/#multi-factor-authentication
 ---
 
 All TTS systems requiring authentication **must** use multiple factors. Examples of multi-factor authentication (MFA) include, but are not limited to:

--- a/_pages/security/scanning.md
+++ b/_pages/security/scanning.md
@@ -2,6 +2,7 @@
 title: Security Scanning
 navtitle: Scanning
 parent: Security
+redirect_to: https://handbook.tts.gsa.gov/security/#security-scanning
 ---
 
 Security scanning is separated into a few categories:

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -2,6 +2,7 @@
 title: Static Security Analysis
 navtitle: Static Analysis
 parent: Security
+redirect_to: https://handbook.tts.gsa.gov/security/#static-analysis
 ---
 
 Static analysis is an important part of the development process, and is required for ATO. There are two main types of static security testing that needs to be done:


### PR DESCRIPTION
***
WARNING: https://github.com/18F/handbook/pull/2531 must be merged first.
***
Closes #526 

This PR sets up redirect links from the Security pages on BYS to the Security page on the Handbook.