### PR TITLE
Set up Infrastructure redirects

### DIFF
--- a/_pages/infrastructure.md
+++ b/_pages/infrastructure.md
@@ -2,6 +2,8 @@
 title: Infrastructure
 redirect_from:
   - /infrastructure/common-questions/
+redirect_to:
+  - https://handbook.tts.gsa.gov/launching-software/infrastructure
 ---
 
 At some point, you're going to want to deploy your system. You have a good idea of the final destination of your system early on

--- a/_pages/infrastructure/aws.md
+++ b/_pages/infrastructure/aws.md
@@ -1,6 +1,7 @@
 ---
 title: Amazon Web Services
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#amazon-web-services
 ---
 
 At TTS, we use [Amazon Web Services](https://aws.amazon.com/) (AWS) as our [infrastructure as a service](https://en.wikipedia.org/wiki/Cloud_computing#Infrastructure_as_a_service_.28IaaS.29) (IaaS). We have separate AWS accounts for our production systems and [sandboxes](../sandbox) for development and testing. If you're used to developing locally, you should feel empowered to do everything you'd like in an AWS [sandbox account](../sandbox). Note that AWS is currently the **only** IaaS provider we are able to use in TTS right now. You're free to develop purely locally as long as you'd like, but _if you want to get a system online, AWS and cloud.gov are your only options_, of which cloud.gov is preferred.

--- a/_pages/infrastructure/aws.md
+++ b/_pages/infrastructure/aws.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Web Services
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#amazon-web-services
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#amazon-web-services
 ---
 
 At TTS, we use [Amazon Web Services](https://aws.amazon.com/) (AWS) as our [infrastructure as a service](https://en.wikipedia.org/wiki/Cloud_computing#Infrastructure_as_a_service_.28IaaS.29) (IaaS). We have separate AWS accounts for our production systems and [sandboxes](../sandbox) for development and testing. If you're used to developing locally, you should feel empowered to do everything you'd like in an AWS [sandbox account](../sandbox). Note that AWS is currently the **only** IaaS provider we are able to use in TTS right now. You're free to develop purely locally as long as you'd like, but _if you want to get a system online, AWS and cloud.gov are your only options_, of which cloud.gov is preferred.

--- a/_pages/infrastructure/certs.md
+++ b/_pages/infrastructure/certs.md
@@ -1,7 +1,7 @@
 ---
 title: HTTPS Certificates
 parent: Infrastructure
-redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#https-certificate
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#https-certificates
 ---
 
 HTTPS should be enforced on every public endpoint ([here's why](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/)). There are a number of ways to get certificates for systems at TTS, depending on what [infrastructure](..) you're using:

--- a/_pages/infrastructure/certs.md
+++ b/_pages/infrastructure/certs.md
@@ -1,7 +1,7 @@
 ---
 title: HTTPS Certificates
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#https-certificate
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#https-certificate
 ---
 
 HTTPS should be enforced on every public endpoint ([here's why](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/)). There are a number of ways to get certificates for systems at TTS, depending on what [infrastructure](..) you're using:

--- a/_pages/infrastructure/certs.md
+++ b/_pages/infrastructure/certs.md
@@ -1,6 +1,7 @@
 ---
 title: HTTPS Certificates
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#https-certificate
 ---
 
 HTTPS should be enforced on every public endpoint ([here's why](https://18f.gsa.gov/2014/11/13/why-we-use-https-in-every-gov-website-we-make/)). There are a number of ways to get certificates for systems at TTS, depending on what [infrastructure](..) you're using:

--- a/_pages/infrastructure/decommissioning.md
+++ b/_pages/infrastructure/decommissioning.md
@@ -1,7 +1,7 @@
 ---
 title: Decommissioning
 parent: infrastructure
-redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#decommissioning
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#decomissioning
 ---
 
 When taking down a production system, [create an issue](https://github.com/18F/tts-tech-portfolio/issues/new?template=decommission.md&title=decommission+%5Bsystem%5D) ([preview](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/decommission.md)). Feel free to add/remove tasks as appropriate, add a username after each task to assign it, and/or make corresponding items in your issue tracker. [Here's a more extensive list](https://github.com/18F/myusa/issues/762). The [General Records Schedules 3.x](https://www.archives.gov/records-mgmt/grs.html) are relevant, as well.

--- a/_pages/infrastructure/decommissioning.md
+++ b/_pages/infrastructure/decommissioning.md
@@ -1,7 +1,7 @@
 ---
 title: Decommissioning
 parent: infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#decommissioning
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#decommissioning
 ---
 
 When taking down a production system, [create an issue](https://github.com/18F/tts-tech-portfolio/issues/new?template=decommission.md&title=decommission+%5Bsystem%5D) ([preview](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/decommission.md)). Feel free to add/remove tasks as appropriate, add a username after each task to assign it, and/or make corresponding items in your issue tracker. [Here's a more extensive list](https://github.com/18F/myusa/issues/762). The [General Records Schedules 3.x](https://www.archives.gov/records-mgmt/grs.html) are relevant, as well.

--- a/_pages/infrastructure/decommissioning.md
+++ b/_pages/infrastructure/decommissioning.md
@@ -1,6 +1,7 @@
 ---
 title: Decommissioning
 parent: infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#decommissioning
 ---
 
 When taking down a production system, [create an issue](https://github.com/18F/tts-tech-portfolio/issues/new?template=decommission.md&title=decommission+%5Bsystem%5D) ([preview](https://github.com/18F/tts-tech-portfolio/blob/master/.github/ISSUE_TEMPLATE/decommission.md)). Feel free to add/remove tasks as appropriate, add a username after each task to assign it, and/or make corresponding items in your issue tracker. [Here's a more extensive list](https://github.com/18F/myusa/issues/762). The [General Records Schedules 3.x](https://www.archives.gov/records-mgmt/grs.html) are relevant, as well.

--- a/_pages/infrastructure/domains.md
+++ b/_pages/infrastructure/domains.md
@@ -1,5 +1,6 @@
 ---
 title: Domains
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#domains
 ---
 
 See also: [Requirements for Federal Websites and Digital Services](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/#domains)

--- a/_pages/infrastructure/domains.md
+++ b/_pages/infrastructure/domains.md
@@ -1,6 +1,6 @@
 ---
 title: Domains
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#domains
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#domains
 ---
 
 See also: [Requirements for Federal Websites and Digital Services](https://digital.gov/resources/checklist-of-requirements-for-federal-digital-services/#domains)

--- a/_pages/infrastructure/federalist.md
+++ b/_pages/infrastructure/federalist.md
@@ -1,7 +1,7 @@
 ---
 title: Federalist
 parent: infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#federalist
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#federalist
 ---
 
 Use Federalist for publishing static sites. See [the Federalist homepage](https://federalist.18f.gov) for more information.

--- a/_pages/infrastructure/federalist.md
+++ b/_pages/infrastructure/federalist.md
@@ -1,6 +1,7 @@
 ---
 title: Federalist
 parent: infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#federalist
 ---
 
 Use Federalist for publishing static sites. See [the Federalist homepage](https://federalist.18f.gov) for more information.

--- a/_pages/infrastructure/good-production-practices.md
+++ b/_pages/infrastructure/good-production-practices.md
@@ -1,6 +1,7 @@
 ---
 title: Good Production Practices
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#good-production-practices
 ---
 
 Below is a list of "good" production ops practices, which product and tech leads should consider early in their development and review as part of any major launch. Items in **bold** are considered must-haves.

--- a/_pages/infrastructure/good-production-practices.md
+++ b/_pages/infrastructure/good-production-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Good Production Practices
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#good-production-practices
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#good-production-practices
 ---
 
 Below is a list of "good" production ops practices, which product and tech leads should consider early in their development and review as part of any major launch. Items in **bold** are considered must-haves.

--- a/_pages/infrastructure/logging.md
+++ b/_pages/infrastructure/logging.md
@@ -1,6 +1,7 @@
 ---
 title: Logging
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#logging
 ---
 
 When using cloud.gov, logs sent to standard out are automatically captured by [logs.fr.cloud.gov](https://logs.fr.cloud.gov). [More info.](https://cloud.gov/docs/apps/logs/)

--- a/_pages/infrastructure/logging.md
+++ b/_pages/infrastructure/logging.md
@@ -1,7 +1,7 @@
 ---
 title: Logging
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#logging
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#logging
 ---
 
 When using cloud.gov, logs sent to standard out are automatically captured by [logs.fr.cloud.gov](https://logs.fr.cloud.gov). [More info.](https://cloud.gov/docs/apps/logs/)

--- a/_pages/infrastructure/monitoring.md
+++ b/_pages/infrastructure/monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#monitoring
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#monitoring
 ---
 
 There are several kinds of monitoring that you will need to have in place for any application:

--- a/_pages/infrastructure/monitoring.md
+++ b/_pages/infrastructure/monitoring.md
@@ -1,6 +1,7 @@
 ---
 title: Monitoring
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#monitoring
 ---
 
 There are several kinds of monitoring that you will need to have in place for any application:

--- a/_pages/infrastructure/pinning-dependencies.md
+++ b/_pages/infrastructure/pinning-dependencies.md
@@ -1,6 +1,7 @@
 ---
 title: Pinning Dependencies
 parent: Good Production Practices
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#pinning-dependencies
 ---
 
 The practice of "pinning dependencies" refers to making explicit the versions

--- a/_pages/infrastructure/pinning-dependencies.md
+++ b/_pages/infrastructure/pinning-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Pinning Dependencies
 parent: Good Production Practices
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#pinning-dependencies
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#pinning-dependencies
 ---
 
 The practice of "pinning dependencies" refers to making explicit the versions

--- a/_pages/infrastructure/sandbox.md
+++ b/_pages/infrastructure/sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: Sandbox Accounts
 parent: Infrastructure
-https://handbook.tts.gsa.gov/launching-software/infrastructure/#sandbox-accounts
+redirect_to: https://handbook.tts.gsa.gov/launching-software/infrastructure/#sandbox-accounts
 ---
 
 Sandbox accounts - both cloud.gov and AWS - are available to all TTS staff for non-production use. Things to bear in mind about sandbox accounts:

--- a/_pages/infrastructure/sandbox.md
+++ b/_pages/infrastructure/sandbox.md
@@ -1,6 +1,7 @@
 ---
 title: Sandbox Accounts
 parent: Infrastructure
+https://handbook.tts.gsa.gov/launching-software/infrastructure/#sandbox-accounts
 ---
 
 Sandbox accounts - both cloud.gov and AWS - are available to all TTS staff for non-production use. Things to bear in mind about sandbox accounts:


### PR DESCRIPTION
Closes #527 

This PR sets up redirect links from the Infrastructure pages on BYS to the Infrastructure page on the Handbook.