### PR TITLE
Fix broken redirect links

### DIFF
--- a/_pages/ato.md
+++ b/_pages/ato.md
@@ -1,6 +1,6 @@
 ---
 title: Lifecycle of a Launch
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#atos
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#atos
 ---
 
 <a href="https://atos.open-control.org/" class="usa-button">Learn about ATOs</a>

--- a/_pages/ato/archer.md
+++ b/_pages/ato/archer.md
@@ -1,7 +1,7 @@
 ---
 title: RSA Archer
 navtitle: Archer
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#rsa-archer
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#rsa-archer
 ---
 
 [RSA Archer](https://www.rsa.com/en-us/products/integrated-risk-management) is the canonical home for system compliance info at GSA. System Owners and Authorizing Officials should automatically have access, but additional read-only access can be [requested for "support staff"](https://docs.google.com/forms/d/e/1FAIpQLSccaOu1DpvnjQjw481iNsLDLEZp0hq3tovZv0xPjYNwnAbnlA/viewform).

--- a/_pages/ato/checklist.md
+++ b/_pages/ato/checklist.md
@@ -1,7 +1,7 @@
 ---
 title: ATO Checklist
 navtitle: Checklist
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#ato-checklist
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#ato-checklist
 ---
 
 The ATO checklist helps you track progress towards a successful launch throughout your project. It is a formatted issue on GitHub, and is the canonical source of information for your path to launch.

--- a/_pages/ato/ssp.md
+++ b/_pages/ato/ssp.md
@@ -1,6 +1,6 @@
 ---
 title: System Security Plan
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#system-security-plan
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#system-security-plan
 ---
 
 As described in [the NIST guide](http://csrc.nist.gov/publications/nistpubs/800-18-Rev1/sp800-18-Rev1-final.pdf#page=7):

--- a/_pages/ato/tips.md
+++ b/_pages/ato/tips.md
@@ -1,6 +1,6 @@
 ---
 title: Tips
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#tips
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#tips
 ---
 
 - Is your project accessible and [Section 508](../../laws/508/) compliant? The team will need to incorporate this throughout the project, but you'll also need to set up a review at least two weeks before launch.

--- a/_pages/ato/types.md
+++ b/_pages/ato/types.md
@@ -1,7 +1,7 @@
 ---
 title: Types of ATO
 navtitle: Types
-redirect_to: https://handbook.tts.gsa.gov/lifecycle/#types-of-ato
+redirect_to: https://handbook.tts.gsa.gov/launching-software/lifecycle/#types-of-ato
 ---
 
 There are several different methods in obtaining a GSA Authorization as described in the policy IT Security Procedural Guide: Managing Enterprise Risk CIO-IT Security-06-30 in [Insite](https://insite.gsa.gov/cdnstatic/insite/Managing_Enterprise_Risk_%5BCIO_IT_Security_06-30_Rev_16%5D_10-03-2019docx.pdf)

--- a/_pages/security.md
+++ b/_pages/security.md
@@ -1,7 +1,7 @@
 ---
 title: General Security Standards
 navtitle: Security
-redirect_to: https://handbook.tts.gsa.gov/security/
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/
 ---
 
 In the Federal government, the principal law governing the security of information systems is the Federal Information Security Modernization Act (FISMA). For more information on FISMA, check out the [FISMA Implementation Project ](https://csrc.nist.gov/projects/risk-management), which will help you stay up to date and in the know about all things FISMA. If you're inclined to see TTS' intepretation of FISMA from a user-center approach, take a look at a previous project from the TTS Tech Portfolio and cloud.gov known as [FISMA Ready](https://github.com/fisma-ready/introduction).  

--- a/_pages/security/dynamic-scanning.md
+++ b/_pages/security/dynamic-scanning.md
@@ -1,7 +1,7 @@
 ---
 title: Dynamic Scanning
 parent: Security
-redirect_to: https://handbook.tts.gsa.gov/security/#dynamic-scanning
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/#dynamic-scanning
 ---
 
 In order for an application to get ATO, it needs to meet more than a minimum level of application security, so the application team needs to run [both static and dynamic security scans](../scanning/) and document good results. Running a "dynamic" scan means running a program that analyzes a live running application for common vulnerabilities.

--- a/_pages/security/frameworks.md
+++ b/_pages/security/frameworks.md
@@ -2,7 +2,7 @@
 title: Framework-Specific Security Guidelines
 navtitle: Frameworks
 parent: Security
-redirect_to: https://handbook.tts.gsa.gov/security/#frameworks
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/#frameworks
 ---
 
 Organized by language.

--- a/_pages/security/mfa.md
+++ b/_pages/security/mfa.md
@@ -1,7 +1,7 @@
 ---
 title: Multi-Factor Authentication
 parent: Security
-redirect_to: https://handbook.tts.gsa.gov/security/#multi-factor-authentication
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/#multi-factor-authentication
 ---
 
 All TTS systems requiring authentication **must** use multiple factors. Examples of multi-factor authentication (MFA) include, but are not limited to:

--- a/_pages/security/scanning.md
+++ b/_pages/security/scanning.md
@@ -2,7 +2,7 @@
 title: Security Scanning
 navtitle: Scanning
 parent: Security
-redirect_to: https://handbook.tts.gsa.gov/security/#security-scanning
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/#security-scanning
 ---
 
 Security scanning is separated into a few categories:

--- a/_pages/security/static-analysis.md
+++ b/_pages/security/static-analysis.md
@@ -2,7 +2,7 @@
 title: Static Security Analysis
 navtitle: Static Analysis
 parent: Security
-redirect_to: https://handbook.tts.gsa.gov/security/#static-analysis
+redirect_to: https://handbook.tts.gsa.gov/launching-software/security/#static-analysis
 ---
 
 Static analysis is an important part of the development process, and is required for ATO. There are two main types of static security testing that needs to be done:


### PR DESCRIPTION
With the URL/directory changes to the Handbook content, the redirects lead to 404s. This PR fixes that.